### PR TITLE
Update "ember-markdown-it" to v0.0.6

### DIFF
--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "frontend",
-  "dependencies": {
-    "markdown-it": "^8.3.1"
-  }
-}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "ember-data": "~2.13.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
-    "ember-markdown-it": "0.0.5",
+    "ember-markdown-it": "^0.0.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.0-beta.1",
     "ember-welcome-page": "^3.0.0",


### PR DESCRIPTION
This removes the `markdown-it` Bower dependency as `ember-markdown-it@0.0.6` will now pull it in via npm