### PR TITLE
Remove clap as a dependency from the Library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ struct Asset {
 
 impl Config {
     pub fn new(manifest_path: PathBuf) -> Result<Config, Box<std::error::Error>> {
-        // unwrap is okay because we take a default value
         let host = generate_analysis(&manifest_path)?;
 
         let assets = vec![Asset {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate jsonapi;
 extern crate rls_analysis as analysis;
 extern crate serde_json;
-extern crate clap;
 
 use analysis::raw::DefKind;
 
@@ -27,9 +26,8 @@ struct Asset {
 }
 
 impl Config {
-    pub fn new(matches: &clap::ArgMatches) -> Result<Config, Box<std::error::Error>> {
+    pub fn new(manifest_path: PathBuf) -> Result<Config, Box<std::error::Error>> {
         // unwrap is okay because we take a default value
-        let manifest_path = PathBuf::from(matches.value_of("manifest-path").unwrap());
         let host = generate_analysis(&manifest_path)?;
 
         let assets = vec![Asset {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
         ))
         .get_matches();
 
+    // unwrap is okay because we take a default value
     let manifest_path = PathBuf::from(&matches.value_of("manifest-path").unwrap());
     let config = Config::new(manifest_path).unwrap_or_else(|err| {
         println!("Problem creating configuration: {}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::{App, Arg, SubCommand};
 use rustdoc::{Config, build};
 
 use std::process;
+use std::path::PathBuf;
 
 fn main() {
     let version = env!("CARGO_PKG_VERSION");
@@ -26,7 +27,8 @@ fn main() {
         ))
         .get_matches();
 
-    let config = Config::new(&matches).unwrap_or_else(|err| {
+    let manifest_path = PathBuf::from(&matches.value_of("manifest-path").unwrap());
+    let config = Config::new(manifest_path).unwrap_or_else(|err| {
         println!("Problem creating configuration: {}", err);
         process::exit(1);
     });


### PR DESCRIPTION
We only want to have the main binary to have the clap crate imported.
This is because it's a command line arg parsing crate. Ideally we would
pass values from it to methods as needed and not pass clap's data types
functions outside of main.

This commit does just that by removing clap from lib.rs and generating
a PathBuf for the Config struct in main.rs instead.

Closes #20