### PR TITLE
Improve travis-ci with rustfmt and eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,14 @@ rust:
   # - beta
   - nightly
 
+cache:
+  - cargo
+
 before_install:
   - nvm install 8.1.4
+  - ./ci-scripts/rustfmt.sh
 
 script:
   - cargo test
+  - rustfmt --write-mode diff src/*
   - cd frontend && npm install && npm run test

--- a/ci-scripts/rustfmt.sh
+++ b/ci-scripts/rustfmt.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+which rustfmt > /dev/null
+
+if [[ $? -ne 0 ]]; then
+  cargo install rustfmt
+else
+  current_version=$(rustfmt --version | cut -d '-' -f 1 | xargs)
+  upstream_version=$(cargo search rustfmt | head -n 1 | cut -d ' ' -f 3 | tr -d '"' | xargs)
+  if [ $current_version != $upstream_version ]; then
+    cargo install rustfmt --force
+  fi
+fi
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,11 +226,12 @@ fn generate_analysis(
 ) -> Result<analysis::AnalysisHost, Box<std::error::Error>> {
     let mut command = Command::new("cargo");
 
-    command.arg("build")
-           .arg("--manifest-path")
-           .arg(manifest_path.join("Cargo.toml"))
-           .env("RUSTFLAGS", "-Z save-analysis")
-           .env("CARGO_TARGET_DIR", manifest_path.join("target/rls"));
+    command
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(manifest_path.join("Cargo.toml"))
+        .env("RUSTFLAGS", "-Z save-analysis")
+        .env("CARGO_TARGET_DIR", manifest_path.join("target/rls"));
 
     print!("generating save analysis data...");
     io::stdout().flush()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,42 +29,44 @@ impl Config {
     pub fn new(manifest_path: PathBuf) -> Result<Config, Box<std::error::Error>> {
         let host = generate_analysis(&manifest_path)?;
 
-        let assets = vec![Asset {
-            name: "crossdomain.xml",
-            contents: include_str!("../frontend/dist/crossdomain.xml"),
-        },
-        Asset {
-            name: "index.html",
-            contents: include_str!("../frontend/dist/index.html"),
-        },
-        Asset {
-            name: "robots.txt",
-            contents: include_str!("../frontend/dist/robots.txt"),
-        },
-        Asset {
-            name: "assets/frontend-c6c060f7a38307646632f4d86abb552b.js",
-            contents: include_str!(
-                "../frontend/dist/assets/frontend-c6c060f7a38307646632f4d86abb552b.js"
-            ),
-        },
-        Asset {
-            name: "assets/frontend-d41d8cd98f00b204e9800998ecf8427e.css",
-            contents: include_str!(
-                "../frontend/dist/assets/frontend-d41d8cd98f00b204e9800998ecf8427e.css"
-            ),
-        },
-        Asset {
-            name: "assets/vendor-12abafe454d5f3c9655736792567755d.js",
-            contents: include_str!(
-                "../frontend/dist/assets/vendor-12abafe454d5f3c9655736792567755d.js"
-            ),
-        },
-        Asset {
-            name: "assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css",
-            contents: include_str!(
-                "../frontend/dist/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css"
-            ),
-        }];
+        let assets = vec![
+            Asset {
+                name: "crossdomain.xml",
+                contents: include_str!("../frontend/dist/crossdomain.xml"),
+            },
+            Asset {
+                name: "index.html",
+                contents: include_str!("../frontend/dist/index.html"),
+            },
+            Asset {
+                name: "robots.txt",
+                contents: include_str!("../frontend/dist/robots.txt"),
+            },
+            Asset {
+                name: "assets/frontend-c6c060f7a38307646632f4d86abb552b.js",
+                contents: include_str!(
+                    "../frontend/dist/assets/frontend-c6c060f7a38307646632f4d86abb552b.js"
+                ),
+            },
+            Asset {
+                name: "assets/frontend-d41d8cd98f00b204e9800998ecf8427e.css",
+                contents: include_str!(
+                    "../frontend/dist/assets/frontend-d41d8cd98f00b204e9800998ecf8427e.css"
+                ),
+            },
+            Asset {
+                name: "assets/vendor-12abafe454d5f3c9655736792567755d.js",
+                contents: include_str!(
+                    "../frontend/dist/assets/vendor-12abafe454d5f3c9655736792567755d.js"
+                ),
+            },
+            Asset {
+                name: "assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css",
+                contents: include_str!(
+                    "../frontend/dist/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css"
+                ),
+            },
+        ];
 
         Ok(Config {
             manifest_path,
@@ -201,11 +203,7 @@ pub fn build(config: &Config) -> Result<(), Box<std::error::Error>> {
     fs::create_dir_all(&assets_path)?;
 
     for asset in &config.assets {
-        create_asset_file(
-            asset.name,
-            &output_path,
-            asset.contents,
-        )?;
+        create_asset_file(asset.name, &output_path, asset.contents)?;
     }
 
     println!("done.");


### PR DESCRIPTION
Currently we had no lint to check that someone had run rustfmt on the
code. This makes sure that someone runs rustfmt so they can pass the CI
checks now. We also wanted eslint to run but according to the
conversation in issue #17 this is already the case when tests are run
using the ember-cli tool.

This adds a ci-scripts folder that we can fill with more scripts we need
run during testing while not cluttering up travis with all kinds of
conditionals and things. In this case we add the rustfmt.sh script which
checks if rustfmt is already installed from the cache and if not to
install it. If it's out of date compared to upstream it'll install the
newest version of rustfmt automatically then cache it for later!

This commit also reformats lib.rs as it was not compliant with rustfmt
and was causing the CI to fail under the new changes

Closes #17