### PR TITLE
Add ability to only output JSON

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate clap;
 
 use clap::{App, Arg, SubCommand};
 
-use rustdoc::{Config, build};
+use rustdoc::{Config, BuildOutput, build};
 
 use std::process;
 use std::path::PathBuf;
@@ -22,14 +22,34 @@ fn main() {
                 .default_value(".")
                 .help("The path to the Cargo manifest of the project you are documenting."),
         )
-        .subcommand(SubCommand::with_name("build").about(
-            "generates documentation",
-        ))
+        .subcommand(
+            SubCommand::with_name("build")
+                .about("generates documentation")
+                .arg(
+                    Arg::with_name("json")
+                        .long("json")
+                        .short("j")
+                        .takes_value(false)
+                        .help("Only output JSON from rustdoc"),
+                ),
+        )
         .get_matches();
 
     // unwrap is okay because we take a default value
     let manifest_path = PathBuf::from(&matches.value_of("manifest-path").unwrap());
-    let config = Config::new(manifest_path).unwrap_or_else(|err| {
+
+    let build_output = match matches.subcommand_matches("build") {
+        Some(j) => {
+            if j.is_present("json") {
+                BuildOutput::Json
+            } else {
+                BuildOutput::All
+            }
+        }
+        None => BuildOutput::All,
+    };
+
+    let config = Config::new(manifest_path, build_output).unwrap_or_else(|err| {
         println!("Problem creating configuration: {}", err);
         process::exit(1);
     });


### PR DESCRIPTION
Currently rustdoc can only output everything needed. We want it to also
only output just the JSON so that others can use it's values to do other
things if they want it. Adds this functionality by adding a flag to
build. The command `rustdoc build -j` or `rustdoc build --json` will
only output JSON now.

Close #27 

@steveklabnik I wasn't sure what you had in mind and this is a preliminary stab at it. currently it just outputs still to `target/doc` with just the JSON. Let me know how you would want this to really work/what can be improved.