### PR TITLE
Add error-chain to handle errors better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "rustdoc"
 version = "0.1.0"
 dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonapi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -34,8 +35,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -55,6 +84,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +109,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "dtoa"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -219,6 +270,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
@@ -429,11 +485,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
+"checksum backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72f9b4182546f4b04ebc4ab7f84948953a118bd6021a1b6a6c909e3e94f6be76"
+"checksum backtrace-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3a0d842ea781ce92be2bf78a9b38883948542749640b8378b3b2f03d1fd9f1ff"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "867a885995b4184be051b70a592d4d70e32d7a188db6e8dff626af286a962771"
+"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41be6ca3b99e0c0483fb2389685448f650459c3ecbe4e18d7705d8010ec4ab8e"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum idna 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2233d4940b1f19f0418c158509cd7396b8d70a5db5705ce410914dc8fa603b37"
 "checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
@@ -454,6 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rls-analysis 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aec345e3f01af7ec54a68f4692e90060c9a28476abb57441c4965049ea487a2b"
 "checksum rls-data 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "374a8fad31cc0681a7bfd8a04079dd4afd0e981d34e18a171b1a467445bdf51e"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
+"checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ rls-analysis = "0.4.0"
 clap = "2.24.2"
 jsonapi = "0.5.2"
 serde_json = "0.9.10"
+error-chain = "0.10.0"
 
 [build-dependencies]
 lazy_static = "0.2.8"
 walkdir = "1.0.7"
+error-chain = "0.10.0"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,23 @@
+#![recursion_limit = "1024"]
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate error_chain;
 extern crate walkdir;
+
 use walkdir::{WalkDir, WalkDirIterator, DirEntry};
 use std::fmt;
 use std::fs::File;
 use std::ffi::OsStr;
-use std::io::{Write, BufWriter};
+use std::io::{Write, BufWriter, stderr};
+use std::process::exit;
+
+error_chain! {
+    foreign_links {
+        Io(::std::io::Error);
+        WalkDir(::walkdir::Error);
+    }
+}
 
 // Location of the dist folder
 const DIST: &str = "frontend/dist/";
@@ -24,18 +36,35 @@ lazy_static! {
 
 /// Find the assets and write out the corresponding files
 pub fn main() {
-    write_asset_file(acquire_assets());
+    if let Err(ref e) = write_asset_file() {
+        let stderr = &mut stderr();
+        let errmsg = "Error writing to stderr";
+
+        writeln!(stderr, "Error: {}", e).expect(errmsg);
+
+        for e in e.iter().skip(1) {
+            writeln!(stderr, "Caused by: {}", e).expect(errmsg);
+        }
+
+        // The backtrace is not always generated. Try to run this example
+        // with `RUST_BACKTRACE=1`.
+        if let Some(backtrace) = e.backtrace() {
+            writeln!(stderr, "Backtrace: {:?}", backtrace).expect(errmsg);
+        }
+
+        exit(1);
+    }
 }
 
 /// Start the recursion from the top level of the frontend's dist folder
-fn acquire_assets() -> Vec<Asset> {
+fn acquire_assets() -> Result<Vec<Asset>> {
     let mut output: Vec<Asset> = Vec::new();
 
     let filter_entries = |e: &DirEntry| !IGNORE.contains(&e.file_name());
 
     for entry in WalkDir::new(DIST).into_iter().filter_entry(filter_entries) {
-        let entry = entry.expect("Unable to read directory entry");
-        if entry.metadata().expect("Couldn't get metadata").is_file() {
+        let entry = entry?;
+        if entry.metadata()?.is_file() {
             output.push(Asset {
                 // If the directory isn't valid this wouldn't have worked.
                 path: String::from(entry.path().to_str().unwrap()).replace("\\", "/"),
@@ -43,18 +72,21 @@ fn acquire_assets() -> Vec<Asset> {
         }
     }
 
-    output
+    Ok(output)
 }
 
 /// Write to asset.in which is a vec expression of static assets that will be
 /// imported using the include!() macro for the `Config` struct
-fn write_asset_file(assets: Vec<Asset>) {
-    let mut writer = BufWriter::new(File::create(ASSETOUT).expect("Unable to create file"));
-    writer.write_all(b"vec![").unwrap();
+fn write_asset_file() -> Result<()> {
+    let assets = acquire_assets()?;
+    let mut writer = BufWriter::new(File::create(ASSETOUT)?);
+    writer.write_all(b"vec![")?;
     for i in assets {
-        writer.write_fmt(format_args!("{},", i)).unwrap();
+        writer.write_fmt(format_args!("{},", i))?;
     }
-    writer.write_all(b"]\n").unwrap();
+    writer.write_all(b"]\n")?;
+
+    Ok(())
 }
 
 /// Intermediary data structure used to hold the path of the file

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,14 @@
+error_chain! {
+    errors {
+        CrateErr(crate_name: &'static str) {
+            description("Crate not found")
+            display("Crate not found: \"{}\"", crate_name)
+        }
+    }
+
+    foreign_links {
+        Io(::std::io::Error);
+        Serde(::serde_json::Error);
+        Analysis(::analysis::AError);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,14 @@
 extern crate jsonapi;
 extern crate rls_analysis as analysis;
 extern crate serde_json;
+#[macro_use]
+extern crate error_chain;
+
+pub mod error;
+use error::*;
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File};
-use std::fmt;
 use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -13,28 +17,6 @@ use std::process::Command;
 use analysis::raw::DefKind;
 use jsonapi::api::JsonApiDocument;
 
-#[derive(Debug)]
-pub struct CrateErr {
-    error: String,
-}
-
-impl CrateErr {
-    pub fn new(crate_name: &str) -> CrateErr {
-        CrateErr { error: format!("Crate not found: \"{}\"", crate_name) }
-    }
-}
-
-impl fmt::Display for CrateErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", &self.error)
-    }
-}
-
-impl std::error::Error for CrateErr {
-    fn description(&self) -> &str {
-        &self.error
-    }
-}
 
 pub struct Config {
     manifest_path: PathBuf,
@@ -51,7 +33,7 @@ struct Asset {
 }
 
 impl Config {
-    pub fn new(manifest_path: PathBuf) -> Result<Config, Box<std::error::Error>> {
+    pub fn new(manifest_path: PathBuf) -> Result<Config> {
         let host = analysis::AnalysisHost::new(analysis::Target::Debug);
 
         let assets = include!("asset.in");
@@ -65,7 +47,7 @@ impl Config {
 }
 
 
-pub fn generate_json(config: &Config) -> Result<JsonApiDocument, Box<std::error::Error>> {
+pub fn generate_json(config: &Config) -> Result<JsonApiDocument> {
     generate_analysis(config)?;
 
     let roots = config.host.def_roots()?;
@@ -81,7 +63,7 @@ pub fn generate_json(config: &Config) -> Result<JsonApiDocument, Box<std::error:
     let id = roots.iter().find(|&&(_, ref name)| name == "example");
     let id = match id {
         Some(&(id, _)) => id,
-        _ => return Err(Box::new(CrateErr::new("example"))),
+        _ => return Err(ErrorKind::CrateErr("example").into()),
     };
 
     let root_def = config.host.get_def(id)?;
@@ -179,7 +161,7 @@ pub fn generate_json(config: &Config) -> Result<JsonApiDocument, Box<std::error:
     Ok(document)
 }
 
-pub fn build(config: &Config, artifacts: &[&str]) -> Result<(), Box<std::error::Error>> {
+pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
     let output_path = config.manifest_path.join("target/doc");
     fs::create_dir_all(&output_path)?;
 
@@ -219,7 +201,7 @@ pub fn build(config: &Config, artifacts: &[&str]) -> Result<(), Box<std::error::
     Ok(())
 }
 
-fn create_asset_file(name: &str, path: &Path, data: &str) -> Result<(), Box<std::error::Error>> {
+fn create_asset_file(name: &str, path: &Path, data: &str) -> Result<()> {
     let mut asset_path = path.to_path_buf();
     asset_path.push(name);
 
@@ -229,7 +211,7 @@ fn create_asset_file(name: &str, path: &Path, data: &str) -> Result<(), Box<std:
     Ok(())
 }
 
-fn generate_analysis(config: &Config) -> Result<(), Box<std::error::Error>> {
+fn generate_analysis(config: &Config) -> Result<()> {
     let mut command = Command::new("cargo");
     let manifest_path = &config.manifest_path;
 


### PR DESCRIPTION
We were using `Box<std::error::Error>` for all of our error handling.
While not bad it makes dealing with them a bit of a pain and error-chain
handles errors very well, making it easy to create our own as well as
interface with other libraries errors. On top of that they end up
chaining well producing a stack of what caused what errors from the
point of origin all the way to the top level. This commit implements all
of the above to give us better more robust error handling.

@steveklabnik as this stand it's assuming the buildscript in #36 get's merged first but since it will be I built this code with that assumption. As you can see error-chain makes all the error handling easy to deal with and the results as well! Take a look and let me know what you think.

Closes #46 