### PR TITLE
Create missing asset sub-directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,6 @@ dependencies = [
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonapi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,5 @@ error-chain = "0.10.0"
 indicatif = "0.6.0"
 
 [build-dependencies]
-lazy_static = "0.2.8"
 walkdir = "1.0.7"
 error-chain = "0.10.0"

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,11 @@
 #![recursion_limit = "1024"]
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate error_chain;
 extern crate walkdir;
 
-use walkdir::{WalkDir, WalkDirIterator, DirEntry};
+use walkdir::WalkDir;
 use std::fmt;
 use std::fs::File;
-use std::ffi::OsStr;
 use std::io::{Write, BufWriter, stderr};
 use std::process::exit;
 
@@ -24,15 +21,6 @@ const DIST: &str = "frontend/dist/";
 
 // Where to write the Assets out to
 const ASSETOUT: &str = "src/asset.in";
-
-// Ignore directories specified here
-lazy_static! {
-    static ref IGNORE: Vec<&'static OsStr> = {
-        vec![
-            OsStr::new("ember-fetch")
-        ]
-    };
-}
 
 /// Find the assets and write out the corresponding files
 pub fn main() {
@@ -60,9 +48,7 @@ pub fn main() {
 fn acquire_assets() -> Result<Vec<Asset>> {
     let mut output: Vec<Asset> = Vec::new();
 
-    let filter_entries = |e: &DirEntry| !IGNORE.contains(&e.file_name());
-
-    for entry in WalkDir::new(DIST).into_iter().filter_entry(filter_entries) {
+    for entry in WalkDir::new(DIST).into_iter() {
         let entry = entry?;
         if entry.metadata()?.is_file() {
             output.push(Asset {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod item;
 use item::item::Metadata;
 
 use std::collections::HashMap;
-use std::fs::{self, File};
+use std::fs::{self, File, DirBuilder};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -124,6 +124,14 @@ fn package_name_from_manifest_path(manifest_path: &Path) -> Result<String> {
 fn create_asset_file(name: &str, path: &Path, data: &str) -> Result<()> {
     let mut asset_path = path.to_path_buf();
     asset_path.push(name);
+
+    // the name may contain one or more directories. we need to create them before trying to create
+    // a file
+    if let Some(parent) = asset_path.parent() {
+        if parent != path {
+            DirBuilder::new().recursive(true).create(parent)?;
+        }
+    }
 
     let mut file = File::create(asset_path)?;
     file.write_all(data.as_bytes())?;


### PR DESCRIPTION
The build process was failing when trying to include the `ember-fetch`
directory. The failure we related to the fact that we were trying to
create the `ember-fetch/fastboot-fetch-a.js` file without the
`ember-watch` director existing in `target/doc`.

Now `create_asset_file` assumes that `name` may be a path with
directories. It will first try to create the necessary directories
before trying to create the file.

Fixes #53