### PR TITLE
Create integration test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,11 @@ dependencies = [
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonapi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -497,6 +500,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "term_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6ae6fb0dcc9bd85f89a1a4adc0df2fd90c90c98849d61433983dd7a9df6363f7"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 "checksum textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f86300c3e7416ee233abd7cda890c492007a3980f941f79185c753a701257167"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,10 @@ indicatif = "0.6.0"
 [build-dependencies]
 walkdir = "1.0.7"
 error-chain = "0.10.0"
+
+[dev-dependencies]
+error-chain = "0.10"
+lazy_static = "0.2"
+regex = "0.2"
+serde_json = "0.9"
+tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ extern crate error_chain;
 extern crate indicatif;
 
 pub mod error;
+pub use error::{Error, ErrorKind};
+
 use error::*;
 
 pub mod item;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ impl DocData {
         Ok(DocData { krate })
     }
 
-    fn to_json(&self) -> Result<String> {
+    pub fn to_json(&self) -> Result<String> {
         use jsonapi::api::*;
 
         let mut document = JsonApiDocument::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use analysis::AnalysisHost;
 use analysis::raw::DefKind;
 use indicatif::ProgressBar;
 
@@ -51,7 +52,8 @@ impl Config {
 pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
     generate_analysis(config)?;
 
-    let data = DocData::new(config)?;
+    let package_name = package_name_from_manifest_path(&config.manifest_path)?;
+    let data = DocData::new(&config.host, &package_name)?;
 
     let output_path = config.manifest_path.join("target/doc");
     fs::create_dir_all(&output_path)?;
@@ -177,22 +179,21 @@ fn generate_analysis(config: &Config) -> Result<()> {
 }
 
 #[derive(Debug)]
-struct DocData {
+pub struct DocData {
     krate: Crate,
 }
 
 impl DocData {
-    fn new(config: &Config) -> Result<DocData> {
-        let roots = config.host.def_roots()?;
+    pub fn new(host: &AnalysisHost, package_name: &str) -> Result<DocData> {
+        let roots = host.def_roots()?;
 
-        let package = package_name_from_manifest_path(&config.manifest_path)?;
-        let id = roots.iter().find(|&&(_, ref name)| name == &package);
+        let id = roots.iter().find(|&&(_, ref name)| name == &package_name);
         let root_id = match id {
             Some(&(id, _)) => id,
             _ => return Err(ErrorKind::CrateErr("example").into()),
         };
 
-        let root_def = config.host.get_def(root_id)?;
+        let root_def = host.get_def(root_id)?;
 
         let name_len = root_def.qualname.len();
         let mut krate = Crate {
@@ -203,10 +204,7 @@ impl DocData {
             metadata: Vec::new(),
         };
 
-        let defs = config.host.for_each_child_def(
-            root_id,
-            |_, def| def.clone(),
-        )?;
+        let defs = host.for_each_child_def(root_id, |_, def| def.clone())?;
 
         for def in defs.into_iter() {
             match def.kind {

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -72,9 +72,9 @@ error_chain! {
 
 /// Create analysis data from a given source file. Returns an analysis host with the data loaded.
 fn generate_analysis(source_file: &Path, tempdir: &Path) -> Result<AnalysisHost> {
-    let source_filename = source_file.to_str().ok_or_else(|| {
-        ErrorKind::Msg("Source filename contained invalid UTF-8".into())
-    })?;
+    let source_filename = source_file.to_str().ok_or_else(
+        || "Source filename contained invalid UTF-8",
+    )?;
 
     let rustc_status = Command::new("rustc")
         .args(&["-Z", "save-analysis"])
@@ -109,7 +109,7 @@ fn check(source_file: &Path, host: &AnalysisHost) -> Result<()> {
     let package_name = source_file
         .file_stem()
         .and_then(|stem| stem.to_str())
-        .ok_or_else(|| ErrorKind::Msg("Invalid source file stem".into()))?;
+        .ok_or_else(|| "Invalid source file stem")?;
     let json = DocData::new(host, package_name)?.to_json()?;
     let json = serde_json::from_str(&json)?;
 

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -157,7 +157,7 @@ fn parse_test(line: &str) -> Option<Result<(String, Regex)>> {
 fn run_test(json: &serde_json::Value, pointer: &str, regex: &Regex) -> Result<()> {
     let value = match json.pointer(pointer) {
         Some(value) => value,
-        None => bail!(ErrorKind::JsonPointer(pointer.to_owned())),
+        None => return Err(ErrorKind::JsonPointer(pointer.to_owned()).into()),
     };
 
     let value = value.as_str().ok_or_else(

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -160,8 +160,8 @@ fn run_test(json: &serde_json::Value, pointer: &str, regex: &Regex) -> Result<()
         None => return Err(ErrorKind::JsonPointer(pointer.to_owned()).into()),
     };
 
-    let value = value.as_str().ok_or_else(
-        || "The JSON pointer pointed at a type other than string",
+    let value = value.as_str().ok_or(
+        "The JSON pointer pointed at a type other than string",
     )?;
 
     if regex.is_match(&value) {

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -60,12 +60,12 @@ error_chain! {
             display("JSON pointer '{}' matched no data", p)
         }
         ValueMismatch(value: String, re: String) {
-            description("the value did not match the regular expression")
-            display("the value '{}' did not match the regular expression '{}'", value, re)
+            description("The value did not match the regular expression")
+            display("The value '{}' did not match the regular expression '{}'", value, re)
         }
         ValueType(value: Value) {
-            description("the JSON pointer did not point at a string")
-            display("the JSON pointer did not point at a string: {:?}", value)
+            description("The JSON pointer did not point at a string")
+            display("The JSON pointer did not point at a string: {:?}", value)
         }
     }
 }
@@ -80,7 +80,7 @@ fn generate_analysis(source_file: &Path, tempdir: &Path) -> Result<AnalysisHost>
         .current_dir(tempdir.to_str().unwrap())
         .status()?;
     if !rustc_status.success() {
-        bail!("compilation of {} failed", source_filename);
+        bail!("Compilation of {} failed", source_filename);
     }
 
     // rls-analysis expects the analysis files to be in a specific directory -- one usually created
@@ -120,7 +120,7 @@ fn check(source_file: &Path, host: &AnalysisHost) -> Result<()> {
     }
 
     if !found_test {
-        bail!("found no tests in {}", source_file.display());
+        bail!("Found no tests in {}", source_file.display());
     }
 
     Ok(())
@@ -155,7 +155,7 @@ fn run_test(json: &serde_json::Value, pointer: &str, regex: &Regex) -> Result<()
     };
 
     let value = value.as_str().ok_or_else(
-        || "the JSON pointer pointed at a type other than string",
+        || "The JSON pointer pointed at a type other than string",
     )?;
 
     if regex.is_match(&value) {

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -99,7 +99,7 @@ fn generate_analysis(source_file: &Path, tempdir: &Path) -> Result<AnalysisHost>
     fs::rename(&save_analysis_dir, &expected_analysis_dir)?;
 
     let host = AnalysisHost::new(Target::Debug);
-    host.reload(&tempdir, &tempdir, true)?;
+    host.reload(tempdir, tempdir, true)?;
 
     Ok(host)
 }
@@ -164,7 +164,7 @@ fn run_test(json: &serde_json::Value, pointer: &str, regex: &Regex) -> Result<()
         "The JSON pointer pointed at a type other than string",
     )?;
 
-    if regex.is_match(&value) {
+    if regex.is_match(value) {
         Ok(())
     } else {
         bail!(ErrorKind::ValueMismatch(
@@ -199,6 +199,8 @@ fn source() {
 }
 
 mod tests {
+    #![cfg_attr(feature = "cargo-clippy", allow(trivial_regex))]
+
     use super::*;
 
     macro_rules! assert_err {

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -1,0 +1,234 @@
+//! Source-based integration tests.
+//!
+//! This file contains a test that will run `rustdoc` on every file in the `tests/source`
+//! directory, and compare the JSON output with comments in the source that indicate the expected
+//! output.
+//!
+//! Supported syntax:
+//!
+//! ```ignore
+//! // @has <JSON pointer> '<Regular expression>'
+//! ```
+//!
+//! This comment requires that the JSON output from `rustdoc` contains a string that matches the
+//! regular expression at the value pointed at by the JSON pointer. See [RFC6901] for JSON pointer
+//! syntax.
+//!
+//! [RFC6901]: https://tools.ietf.org/html/rfc6901
+
+extern crate rustdoc;
+
+#[macro_use]
+extern crate error_chain;
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate serde_json;
+
+extern crate regex;
+extern crate rls_analysis as analysis;
+extern crate tempdir;
+
+use std::fs::{self, File};
+use std::io::{self, BufReader};
+use std::io::prelude::*;
+use std::path::Path;
+use std::process::Command;
+
+use analysis::{AnalysisHost, Target};
+use regex::Regex;
+use serde_json::Value;
+use tempdir::TempDir;
+
+use rustdoc::DocData;
+
+error_chain! {
+    foreign_links {
+        Analysis(analysis::AError);
+        Io(io::Error);
+        Json(serde_json::Error);
+        Regex(regex::Error);
+    }
+
+    links {
+        Rustdoc(rustdoc::error::Error, rustdoc::error::ErrorKind);
+    }
+
+    errors {
+        JsonPointer(p: String) {
+            description("JSON pointer matched no data")
+            display("JSON pointer '{}' matched no data", p)
+        }
+        ValueMismatch(value: String, re: String) {
+            description("the value did not match the regular expression")
+            display("the value '{}' did not match the regular expression '{}'", value, re)
+        }
+        ValueType(value: Value) {
+            description("the JSON pointer did not point at a string")
+            display("the JSON pointer did not point at a string: {:?}", value)
+        }
+    }
+}
+
+/// Create analysis data from a given source file. Returns an analysis host with the data loaded.
+fn generate_analysis(source_file: &Path, tempdir: &Path) -> Result<AnalysisHost> {
+    let source_filename = source_file.to_str().unwrap();
+
+    let rustc_status = Command::new("rustc")
+        .args(&["-Z", "save-analysis"])
+        .arg(source_filename)
+        .current_dir(tempdir.to_str().unwrap())
+        .status()?;
+    if !rustc_status.success() {
+        bail!("compilation of {} failed", source_filename);
+    }
+
+    // rls-analysis expects the analysis files to be in a specific directory -- one usually created
+    // by cargo.
+    let save_analysis_dir = tempdir.join("save-analysis-temp");
+    let expected_analysis_dir = tempdir
+        .join("target")
+        .join("rls")
+        .join(&Target::Debug.to_string())
+        .join("save-analysis");
+    fs::create_dir_all(&expected_analysis_dir)?;
+    fs::rename(&save_analysis_dir, &expected_analysis_dir)?;
+
+    let host = AnalysisHost::new(Target::Debug);
+    host.reload(&tempdir, &tempdir, true)?;
+
+    Ok(host)
+}
+
+/// Runs all tests in a given source file.
+fn check(source_file: &Path, host: &AnalysisHost) -> Result<()> {
+    let package_name = source_file.file_stem().unwrap();
+    let json = DocData::new(host, package_name.to_str().unwrap())?
+        .to_json()?;
+    let json = serde_json::from_str(&json)?;
+
+    let source = BufReader::new(File::open(source_file)?);
+    let mut found_test = false;
+    for line in source.lines() {
+        if let Some(test_case) = parse_test(&line?) {
+            let (pointer, regex) = test_case?;
+            run_test(&json, &pointer, &regex)?;
+            if !found_test {
+                found_test = true;
+            }
+        }
+    }
+
+    if !found_test {
+        bail!("found no tests in {}", source_file.display());
+    }
+
+    Ok(())
+}
+
+/// Optionally parses a test case from a single line. If the line contains a test case, returns a
+/// Result containing a tuple of the JSON pointer and the regular expression. If there is no test
+/// case contained in the line, returns `None`.
+fn parse_test(line: &str) -> Option<Result<(String, Regex)>> {
+    lazy_static! {
+        static ref COMMAND_RE: Regex =
+            Regex::new("@has (?P<pointer>[a-z/]+) '(?P<match>.+)'").unwrap();
+    }
+
+    if let Some(caps) = COMMAND_RE.captures(line) {
+        let regex = match Regex::new(&caps["match"]) {
+            Ok(regex) => regex,
+            Err(err) => return Some(Err(err.into())),
+        };
+        let pointer = caps["pointer"].to_owned();
+        Some(Ok((pointer, regex)))
+    } else {
+        None
+    }
+}
+
+/// Compares a JSON pointer against a Regex.
+fn run_test(json: &serde_json::Value, pointer: &str, regex: &Regex) -> Result<()> {
+    let value = match json.pointer(pointer) {
+        Some(value) => value,
+        None => bail!(ErrorKind::JsonPointer(pointer.to_owned())),
+    };
+
+    let value = value.as_str().ok_or_else(
+        || "the JSON pointer pointed at a type other than string",
+    )?;
+
+    if regex.is_match(&value) {
+        Ok(())
+    } else {
+        bail!(ErrorKind::ValueMismatch(
+            value.to_owned(),
+            regex.as_str().to_owned(),
+        ));
+    }
+}
+
+/// The test that actually checks all the source tests.
+///
+/// Consider generating these tests in the build script to allow parallelism.
+#[test]
+fn source() {
+    let source_dir = Path::new("tests/source");
+    let tempdir = TempDir::new("rustdoc-test").unwrap();
+
+    for source_file in fs::read_dir(source_dir).unwrap() {
+        let source_file = source_file.unwrap();
+        print!(
+            "checking {} ... ",
+            source_file.file_name().to_str().unwrap()
+        );
+
+        let source_file = std::env::current_dir().unwrap().join(source_file.path());
+        let host = generate_analysis(&source_file, tempdir.path()).unwrap();
+        check(&source_file, &host).unwrap();
+
+        io::stdout().flush().unwrap();
+        println!("ok");
+    }
+}
+
+mod tests {
+    use super::*;
+
+    macro_rules! assert_err {
+        ($err:expr, $kind:path) => {
+            match *($err).kind() {
+                $kind(..) => (),
+                ref kind => panic!("unexpected error kind: {:?}", kind),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_test() {
+        let (pointer, regex) = super::parse_test("// @has /test 'value'").unwrap().unwrap();
+        assert_eq!(pointer, "/test");
+        assert_eq!(regex.as_str(), "value");
+
+        assert!(super::parse_test(r#"fn main() { println!("no test case"); }"#).is_none());
+
+        let err = super::parse_test("// @has /test '['").unwrap().unwrap_err();
+        assert_err!(err, ErrorKind::Regex);
+    }
+
+    #[test]
+    fn run_test() {
+        let json = json!({
+            "test": "value",
+        });
+
+        assert!(super::run_test(&json, "/test", &Regex::new("value").unwrap()).is_ok());
+
+        let err = super::run_test(&json, "/test", &Regex::new("wrong value").unwrap()).unwrap_err();
+        assert_err!(err, ErrorKind::ValueMismatch);
+
+        let err = super::run_test(&json, "/nonexistent", &Regex::new("value").unwrap())
+            .unwrap_err();
+        assert_err!(err, ErrorKind::JsonPointer);
+    }
+}

--- a/tests/source/crate_docs.rs
+++ b/tests/source/crate_docs.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+
+//! Crate docs
+
+// @has /data/attributes/docs 'Crate docs'


### PR DESCRIPTION
This PR adds a way to write integration tests that assert the JSON output from rustdoc is as expected. The syntax is inspired by the rustdoc tests in the compiler, but please bikeshed! Criticism welcome.

Current limitations (to be addressed in future PRs):

- Only `@has` is supported.
- Test comments must be across a single line.
- Test file name must match crate name.
- Tests may only match regexes against strings in JSON. Do we want to allow matching against objects, arrays, etc.?
- Roundtrips the doc JSON into a String

cc #13 

