### PR TITLE
Lookup crate name instead of package name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 error_chain! {
     errors {
-        CrateErr(crate_name: &'static str) {
+        CrateErr(crate_name: String) {
             description("Crate not found")
             display("Crate not found: \"{}\"", crate_name)
         }


### PR DESCRIPTION
The package name and crate name are often the same, but may be different.

Fixes #51