### PR TITLE
Revert appveyor fix since upstream fixed it

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,9 +12,3 @@ test_script:
   - cargo build
  # see https://github.com/steveklabnik/rustdoc/issues/22
  #- cargo test
- 
-# https://twitter.com/RustStatus/status/887694846890307584
-# https://twitter.com/RustStatus/status/887703618115297280
-environment:
-  RUSTUP_USE_HYPER: 1
-  CARGO_HTTP_CHECK_REVOKE: false


### PR DESCRIPTION
appveyor builds were failing due to ssl issues but they've been fixed
upstream. We don't need this workaround anymore:

https://github.com/appveyor/ci/issues/1669