### PR TITLE
Improve fetching the defs

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -33,3 +33,14 @@ pub fn sample_function(x: i32) -> ExampleStruct {
 pub mod example_module {
     pub struct AnotherStruct;
 }
+
+/// nested 1
+pub mod nested1 {
+    /// nested 2
+    pub mod nested2 {
+        /// nested 3
+        pub mod nested3 {
+
+        }
+    }
+}


### PR DESCRIPTION
EDIT: the below was true when i opened this PR, with rayon, but I've since pulled it out.

---------------------

thank you based @sp3d for helping me get this to compile

The next big step is to start fetching more than just the first-level defs. 😄 

I'm opening this PR, not because I plan on merging, but because I think it's not great and wondered if others had good feedback. I talked to @nikomatsakis about this earlier, and there's two problems here:

1. it's not actually clear that doing this with rayon is going to be much faster, as there's not that much work to actually do
2. this is sort of half-way between a "pure channels" model and a "pure rayon" model, so it kind of inherits the worst of both worlds.

I'm going to continue working on the next steps after this (specifically, while this now renders all of the submodules, they're not nested, because the JSON generating code is also bad) but in the meantime, if any of you want to hack on improving this code, feel free to leave comments or send a PR to my PR 😄 
