### PR TITLE
Test fixups

### DIFF
--- a/tests/source.rs
+++ b/tests/source.rs
@@ -208,9 +208,9 @@ fn run_test(json: &serde_json::Value, pointer: &str, regex: &Regex) -> Result<()
 #[test]
 fn source() {
     let source_dir = Path::new("tests/source");
-    let tempdir = TempDir::new("rustdoc-test").unwrap();
 
     for source_file in fs::read_dir(source_dir).unwrap() {
+        let tempdir = TempDir::new("rustdoc-test").unwrap();
         let source_file = source_file.unwrap();
         print!(
             "checking {} ... ",

--- a/tests/source/module_docs.rs
+++ b/tests/source/module_docs.rs
@@ -1,0 +1,11 @@
+#![crate_type = "lib"]
+
+//! Crate docs
+
+// @has /data/attributes/docs 'Crate docs'
+// @has /included/0/attributes/docs 'a module'
+
+/// a module
+mod mod1 {
+
+}


### PR DESCRIPTION
In https://github.com/steveklabnik/rustdoc/pull/61, @euclio added a test runner. In https://github.com/steveklabnik/rustdoc/pull/67 i got them building on Windows.

Adding a second test was failing, because keeping the same TempDir for every test meant that old files were lying around, which made the runner confused. The easiest thing is to make a temporary directory per test.

I also added a second test, testing module stuff. I'm going to build on this for the nested module stuff I'm working on next.

@euclio what do you think?