### PR TITLE
Fix issue with ids being cut off

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,11 +197,9 @@ impl DocData {
 
         let root_def = host.get_def(root_id)?;
 
-        let name_len = root_def.qualname.len();
         let mut krate = Crate {
             id: root_id,
-            // example:: -> example
-            name: root_def.qualname[..(name_len - 2)].to_string(),
+            name: root_def.qualname.to_string(),
             docs: root_def.docs.clone(),
             metadata: Vec::new(),
         };

--- a/tests/source/crates.rs
+++ b/tests/source/crates.rs
@@ -3,8 +3,6 @@
 //! Crate docs
 
 // @has /data/type 'crate'
-
-// FIXME: https://github.com/steveklabnik/rustdoc/issues/80
-// @has /data/id 'crat'
+// @has /data/id 'crates'
 
 // @has /data/attributes/docs 'Crate docs'


### PR DESCRIPTION
We used to strip off ::, but it seems it's no longer included; must have
been an upstream bug.

Fixes #80