### PR TITLE
move asset-related functions to module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 target/
 **/*.rs.bk
-src/asset.in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,15 @@ doc = false
 doctest = false
 
 [dependencies]
-rls-analysis = "0.4.0"
 clap = "2.24.2"
+error-chain = "0.10.0"
+indicatif = "0.6.0"
+lazy_static = "0.2"
+rayon = "0.8.2"
+rls-analysis = "0.4.0"
 serde = "1.0.11"
 serde_derive = "1.0.11"
 serde_json = "1.0.2"
-error-chain = "0.10.0"
-indicatif = "0.6.0"
-rayon = "0.8.2"
 
 [build-dependencies]
 error-chain = "0.10.0"
@@ -30,9 +31,9 @@ walkdir = "1.0.7"
 
 [dev-dependencies]
 error-chain = "0.10"
+jsonapi = "0.5.2"
 lazy_static = "0.2"
 regex = "0.2"
-shlex = "0.1"
 serde_json = "1.0.2"
-jsonapi = "0.5.2"
+shlex = "0.1"
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 clap = "2.24.2"
 error-chain = "0.10.0"
 indicatif = "0.6.0"
-lazy_static = "0.2"
 rayon = "0.8.2"
 rls-analysis = "0.4.0"
 serde = "1.0.11"

--- a/build.rs
+++ b/build.rs
@@ -115,7 +115,7 @@ impl fmt::Display for Asset {
 
         let asset =
             format!(
-            r#"Asset {{
+            r#"rustdoc::assets::Asset {{
                 name: "{name}",
                 contents: include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/{path}")),
             }}"#,

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,0 +1,47 @@
+//! Functions and data type declarations for copying frontend assets to the target directory.
+
+use std::fs::{DirBuilder, File};
+use std::io::prelude::*;
+use std::path::Path;
+
+use error::*;
+
+lazy_static! {
+    /// The assets to be output in the target directory.
+    pub static ref ASSETS: Vec<Asset> = include!(concat!(env!("OUT_DIR"), "/asset.in"));
+}
+
+/// Static assets compiled into the binary so we get a single executable. These are dynamically
+/// generated with the build script based off of items in the `frontend/dist` folder.
+pub struct Asset {
+    /// Relative path of the file
+    pub name: &'static str,
+
+    /// Contents of the file
+    pub contents: &'static str,
+}
+
+/// Output an asset file to a given directory
+///
+/// ## Arguments
+///
+/// - name: Name of the asset file
+/// - path: Path to the directory to write the file out to
+/// - data: Data to be written to the file
+pub fn create_asset_file(name: &str, path: &Path, data: &str) -> Result<()> {
+    let mut asset_path = path.to_path_buf();
+    asset_path.push(name);
+
+    // the name may contain one or more directories. we need to create them before trying to create
+    // a file
+    if let Some(parent) = asset_path.parent() {
+        if parent != path {
+            DirBuilder::new().recursive(true).create(parent)?;
+        }
+    }
+
+    let mut file = File::create(asset_path)?;
+    file.write_all(data.as_bytes())?;
+
+    Ok(())
+}

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -6,11 +6,6 @@ use std::path::Path;
 
 use error::*;
 
-lazy_static! {
-    /// The assets to be output in the target directory.
-    pub static ref ASSETS: Vec<Asset> = include!(concat!(env!("OUT_DIR"), "/asset.in"));
-}
-
 /// Static assets compiled into the binary so we get a single executable. These are dynamically
 /// generated with the build script based off of items in the `frontend/dist` folder.
 pub struct Asset {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate serde_derive;
 
 extern crate indicatif;
@@ -31,6 +29,7 @@ use analysis::raw::DefKind;
 use indicatif::ProgressBar;
 use rayon::prelude::*;
 
+use assets::Asset;
 use error::*;
 use item::Metadata;
 use json::*;
@@ -48,6 +47,7 @@ pub use error::{Error, ErrorKind};
 pub struct Config {
     manifest_path: PathBuf,
     host: analysis::AnalysisHost,
+    assets: Vec<Asset>,
 }
 
 impl Config {
@@ -57,12 +57,13 @@ impl Config {
     /// ## Arguments
     ///
     /// - manifest_path: The path to the location of `Cargo.toml` of the crate being documented
-    pub fn new(manifest_path: PathBuf) -> Result<Config> {
+    pub fn new(manifest_path: PathBuf, assets: Vec<Asset>) -> Result<Config> {
         let host = analysis::AnalysisHost::new(analysis::Target::Debug);
 
         Ok(Config {
             manifest_path,
             host,
+            assets,
         })
     }
 }
@@ -108,7 +109,7 @@ pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
         assets_path.push("assets");
         fs::create_dir_all(&assets_path)?;
 
-        for asset in assets::ASSETS.iter() {
+        for asset in &config.assets {
             assets::create_asset_file(asset.name, &output_path, asset.contents)?;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,8 @@ fn main() {
 
     // unwrap is okay because we take a default value
     let manifest_path = PathBuf::from(&matches.value_of("manifest-path").unwrap());
-    let config = Config::new(manifest_path).unwrap_or_else(|err| {
+    let assets = include!(concat!(env!("OUT_DIR"), "/asset.in"));
+    let config = Config::new(manifest_path, assets).unwrap_or_else(|err| {
         println!("Problem creating configuration: {}", err);
         process::exit(1);
     });

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -10,7 +10,7 @@ mod validation_tests {
 
     #[test]
     fn json_fmt_test() {
-        let config = Config::new(PathBuf::from("example")).unwrap_or_else(|err| {
+        let config = Config::new(PathBuf::from("example"), vec![]).unwrap_or_else(|err| {
             panic!("Couldn't create the config: {}", err);
         });
 


### PR DESCRIPTION
Also generates the asset code in the target directory, instead of the
src directory. This decouples the asset generation location from its
inclusion.