### PR TITLE
Factor cargo-related functions into module

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,0 +1,44 @@
+//! Functions for retrieving package data from `cargo`.
+
+use serde_json;
+
+use error::*;
+
+/// Parse the crate name of the binary or library from crate metadata.
+///
+/// ## Arguments
+///
+/// - metadata: The JSON metadata of the crate.
+pub fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> {
+    let targets = match metadata["packages"][0]["targets"].as_array() {
+        Some(targets) => targets,
+        None => return Err(ErrorKind::Json("targets is not an array").into()),
+    };
+
+    for target in targets {
+        let crate_types = match target["crate_types"].as_array() {
+            Some(crate_types) => crate_types,
+            None => return Err(ErrorKind::Json("crate types is not an array").into()),
+        };
+
+        for crate_type in crate_types {
+            let ty = match crate_type.as_str() {
+                Some(t) => t,
+                None => {
+                    return Err(
+                        ErrorKind::Json("crate type contents are not a string").into(),
+                    )
+                }
+            };
+
+            if ty == "lib" {
+                match target["name"].as_str() {
+                    Some(name) => return Ok(name.to_string()),
+                    None => return Err(ErrorKind::Json("target name is not a string").into()),
+                }
+            }
+        }
+    }
+
+    Err(ErrorKind::Json("cargo metadata").into())
+}

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -40,5 +40,7 @@ pub fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> 
         }
     }
 
-    Err(ErrorKind::Json("cargo metadata").into())
+    Err(
+        ErrorKind::Json("cargo metadata contained no targets").into(),
+    )
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -33,7 +33,7 @@ pub fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> 
 
             if ty == "lib" {
                 match target["name"].as_str() {
-                    Some(name) => return Ok(name.to_string()),
+                    Some(name) => return Ok(name.replace('-', "_")),
                     None => return Err(ErrorKind::Json("target name is not a string").into()),
                 }
             }
@@ -43,4 +43,40 @@ pub fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> 
     Err(
         ErrorKind::Json("cargo metadata contained no targets").into(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_name_from_metadata() {
+        let metadata = json!({
+            "packages": [
+                {
+                    "name": "underscored_name",
+                    "targets": [
+                        {
+                            "crate_types": [ "lib" ],
+                            "name": "underscored_name",
+                        },
+                    ],
+                },
+            ],
+        });
+        assert_eq!(&super::crate_name_from_metadata(&metadata).unwrap(), "underscored_name");
+
+        let metadata = json!({
+            "packages": [
+                {
+                    "name": "dashed-name",
+                    "targets": [
+                        {
+                            "crate_types": [ "lib" ],
+                            "name": "dashed-name",
+                        },
+                    ],
+                },
+            ],
+        });
+        assert_eq!(&super::crate_name_from_metadata(&metadata).unwrap(), "dashed_name");
+    }
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,15 +1,49 @@
 //! Functions for retrieving package data from `cargo`.
 
+use std::path::Path;
+use std::process::Command;
+
 use serde_json;
 
 use error::*;
+
+/// Grab the name of the binary or library from it's `Cargo.toml` file.
+///
+/// ## Arguments
+///
+/// - manifest_path: The path to the location of `Cargo.toml` of the crate being documented
+pub fn crate_name_from_manifest_path(manifest_path: &Path) -> Result<String> {
+    let mut command = Command::new("cargo");
+
+    command
+        .arg("metadata")
+        .arg("--manifest-path")
+        .arg(manifest_path.join("Cargo.toml"))
+        .arg("--no-deps")
+        .arg("--format-version")
+        .arg("1");
+
+    let output = command.output()?;
+
+    if !output.status.success() {
+        return Err(
+            ErrorKind::Cargo(
+                output.status,
+                String::from_utf8_lossy(&output.stderr).into_owned(),
+            ).into(),
+        );
+    }
+
+    let metadata = serde_json::from_slice(&output.stdout)?;
+    crate_name_from_metadata(&metadata)
+}
 
 /// Parse the crate name of the binary or library from crate metadata.
 ///
 /// ## Arguments
 ///
 /// - metadata: The JSON metadata of the crate.
-pub fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> {
+fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> {
     let targets = match metadata["packages"][0]["targets"].as_array() {
         Some(targets) => targets,
         None => return Err(ErrorKind::Json("targets is not an array").into()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,13 @@
 extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
+#[cfg_attr(test, macro_use)]
+extern crate serde_json;
 
 extern crate indicatif;
 extern crate rayon;
 extern crate rls_analysis as analysis;
 extern crate serde;
-extern crate serde_json;
 
 pub mod assets;
 pub mod cargo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,11 +158,17 @@ fn crate_name_from_manifest_path(manifest_path: &Path) -> Result<String> {
 /// - config: Contains data for what needs to be output or used. In this case the path to the
 ///           `Cargo.toml` file
 fn generate_analysis(config: &Config) -> Result<()> {
-    let mut command = Command::new("cargo");
     let manifest_path = &config.manifest_path;
 
+    // FIXME: Here we assume that we are documenting a library. This could be wrong, but it's the
+    // common case, and it ensures that we are documenting the right target in the case that the
+    // crate contains a binary and a library with the same name.
+    //
+    // Maybe we could use Cargo.toml's `doc = false` attribute to figure out the right target?
+    let mut command = Command::new("cargo");
     command
         .arg("check")
+        .arg("--lib")
         .arg("--manifest-path")
         .arg(manifest_path.join("Cargo.toml"))
         .env("RUSTFLAGS", "-Z save-analysis")


### PR DESCRIPTION
Also fixes a few bugs:

- Looks like #51 wasn't quite fixed: the crate name isn't actually in the cargo metadata, but it's easily inferrable by replacing dashes in the target name with underscores.
- Unconditionally generates metadata for the library. See the FIXME comment. Another option could be to provide a `--bin` or `--lib` flag to rustdoc. This shouldn't be too hard to fix, but I think it can be tackled in a separate PR. 

