### PR TITLE
store asset contents as bytes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -117,7 +117,7 @@ impl fmt::Display for Asset {
             format!(
             r#"rustdoc::assets::Asset {{
                 name: "{name}",
-                contents: include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/{path}")),
+                contents: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/{path}")),
             }}"#,
             name = name,
             path = self.path,

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -13,7 +13,7 @@ pub struct Asset {
     pub name: &'static str,
 
     /// Contents of the file
-    pub contents: &'static str,
+    pub contents: &'static [u8],
 }
 
 /// Output an asset file to a given directory
@@ -23,7 +23,7 @@ pub struct Asset {
 /// - name: Name of the asset file
 /// - path: Path to the directory to write the file out to
 /// - data: Data to be written to the file
-pub fn create_asset_file(name: &str, path: &Path, data: &str) -> Result<()> {
+pub fn create_asset_file(name: &str, path: &Path, data: &[u8]) -> Result<()> {
     let mut asset_path = path.to_path_buf();
     asset_path.push(name);
 
@@ -36,7 +36,7 @@ pub fn create_asset_file(name: &str, path: &Path, data: &str) -> Result<()> {
     }
 
     let mut file = File::create(asset_path)?;
-    file.write_all(data.as_bytes())?;
+    file.write_all(data)?;
 
     Ok(())
 }


### PR DESCRIPTION
Some files (PNGs, etc.) are not valid UTF-8, which will cause
`include_str!` to fail.