### PR TITLE
Add structs to data.json

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1,42 +1,20 @@
 //! Function and data type declarations for dealing with Rust's different types of items available
 //! to it like a `struct`, `const`, or an `enum`
 
+use analysis::raw::DefKind;
+
+/// Struct containing different types of data about definitions possibly in a Rust Code Base
 #[derive(Debug)]
-/// Enum containing different types of data about an items possibly in a Rust Code Base
-pub enum Metadata {
-    /// Data associated with module definitions
-    Module {
-        /// Full path to the item in the module hierarchy
-        qualified_name: String,
-        /// Name of the module
-        name: String,
-        /// Doc String associated with the module
-        docs: String,
-    },
-    /// Data associated with `static` definitions
-    Static {},
-    /// Data associated with `const` definitions
-    Const {},
-    /// Data associated with `enum` definitions
-    Enum {},
-    /// Data associated with `struct` definitions
-    Struct {},
-    /// Data associated with `union` definitions
-    Union {},
-    /// Data associated with `trait` definitions
-    Trait {},
-    /// Data associated with `fn` definitions
-    Function {},
-    /// Data associated with `macro` definitions
-    Macro {},
-    /// Data associated with `tuple` definitions
-    Tuple {},
-    /// Data associated with `method` definitions
-    Method {},
-    /// Data associated with `type` definitions
-    Type {},
-    /// Data associated with `local` definitions
-    Local {},
-    /// Data associated with `field` definitions
-    Field {},
+pub struct Metadata {
+    /// What kind of definition: module, struct, function, etc.
+    pub kind: DefKind,
+
+    /// Full path to the item in the module hierarchy
+    pub qualified_name: String,
+
+    /// Name of the definition
+    pub name: String,
+
+    /// Documentation associated with the definition
+    pub docs: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,48 +227,32 @@ impl DocData {
 
     /// Serialize the data structure into a valid `JSON API` String for output later.
     pub fn to_json(&self) -> Result<String> {
-
         // Set up the values we'll later push into the to `Documentation` struct to be serialized
         let mut included: Vec<Document> = Vec::new();
         let mut relationships: HashMap<&str, Vec<Data>> = HashMap::with_capacity(METADATA_SIZE);
 
         // Check each item in the metadata and add it to be serialized based off it's type
-        for item in self.metadata.iter() {
-            let Metadata {
-                ref kind,
-                ref qualified_name,
-                ref name,
-                ref docs,
-            } = *item;
-            match *kind {
-                DefKind::Mod => {
-                    // The `relationships` `HashMap` had a module value added before so we push this
-                    // new module relationship into it
-                    if let Some(ref mut vec) = relationships.get_mut("modules") {
-                        vec.push(Data::new().ty("module").id(&qualified_name));
-                    }
+        for item in &self.metadata {
+            let (ty, relations_key) = match item.kind {
+                DefKind::Mod => ("module", "modules"),
+                DefKind::Struct => ("struct", "structs"),
+                _ => continue,
+            };
 
-                    // We do this to avoid borrow check errors regarding two mutable references.
-                    // A "modules" value was never inserted into the HashMap before so we create it
-                    if let None = relationships.get("modules") {
-                        relationships.insert(
-                            "modules",
-                            vec![Data::new().ty("module").id(&qualified_name)],
-                        );
-                    }
+            // Using the item's metadata we create a new `Document` type to be put in the eventual
+            // serialized JSON.
+            included.push(
+                Document::new()
+                    .ty(ty)
+                    .id(&item.qualified_name)
+                    .attributes("name", &item.name)
+                    .attributes("docs", &item.docs),
+            );
 
-                    // Using the module's metadata we create a new `Document` type to be put in the
-                    // eventual serialized JSON
-                    let module = Document::new()
-                        .ty("module")
-                        .id(&qualified_name)
-                        .attributes("name", name)
-                        .attributes("docs", docs);
-
-                    included.push(module);
-                }
-                _ => {}
-            }
+            let item_relationships = relationships.entry(relations_key).or_insert_with(
+                Default::default,
+            );
+            item_relationships.push(Data::new().ty(ty).id(&item.qualified_name));
         }
 
         let len = self.name.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,32 +210,17 @@ impl DocData {
             defs
         }
 
-        let defs: Vec<analysis::Def> = recur(&root_id, host);
-
-        for def in defs.into_iter() {
-            match def.kind {
-                DefKind::Mod => {
-                    doc_data.metadata.push(Metadata::Module {
-                        qualified_name: def.qualname,
-                        name: def.name,
-                        docs: def.docs,
-                    });
+        doc_data.metadata = recur(&root_id, host)
+            .into_iter()
+            .map(|def| {
+                Metadata {
+                    kind: def.kind,
+                    qualified_name: def.qualname,
+                    name: def.name,
+                    docs: def.docs,
                 }
-                DefKind::Static => (),
-                DefKind::Const => (),
-                DefKind::Enum => (),
-                DefKind::Struct => (),
-                DefKind::Union => (),
-                DefKind::Trait => (),
-                DefKind::Function => (),
-                DefKind::Macro => (),
-                DefKind::Tuple => (),
-                DefKind::Method => (),
-                DefKind::Type => (),
-                DefKind::Local => (),
-                DefKind::Field => (),
-            }
-        }
+            })
+            .collect();
 
         Ok(doc_data)
     }
@@ -249,13 +234,14 @@ impl DocData {
 
         // Check each item in the metadata and add it to be serialized based off it's type
         for item in self.metadata.iter() {
-            match item {
-                &Metadata::Module {
-                    ref qualified_name,
-                    ref name,
-                    ref docs,
-                } => {
-
+            let Metadata {
+                ref kind,
+                ref qualified_name,
+                ref name,
+                ref docs,
+            } = *item;
+            match *kind {
+                DefKind::Mod => {
                     // The `relationships` `HashMap` had a module value added before so we push this
                     // new module relationship into it
                     if let Some(ref mut vec) = relationships.get_mut("modules") {

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+
+/// A unit struct.
+pub struct UnitStruct;
+
+// @has /included/0/type 'struct'
+// @has /included/0/id 'structs::UnitStruct'
+// @has /included/0/attributes/name 'UnitStruct'
+// @has /included/0/attributes/docs 'A unit struct.'
+// @has /data/relationships/structs/data/0/id 'structs::UnitStruct'


### PR DESCRIPTION
Fields are not supported.

Refactors the `Metadata` enum into a struct to share common fields.