### PR TITLE
Let rustdoc work with workspaced crates [WIP]

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -8,6 +8,7 @@ use error::*;
 
 /// Static assets compiled into the binary so we get a single executable. These are dynamically
 /// generated with the build script based off of items in the `frontend/dist` folder.
+#[derive(Copy, Clone)]
 pub struct Asset {
     /// Relative path of the file
     pub name: &'static str,

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -30,12 +30,25 @@ pub fn generate_analysis(manifest_path: &Path) -> Result<()> {
     let output = command.output()?;
 
     if !output.status.success() {
-        return Err(
-            ErrorKind::Cargo(
-                output.status,
-                String::from_utf8_lossy(&output.stderr).into_owned(),
-            ).into(),
-        );
+        let mut command = Command::new("cargo");
+        command
+            .arg("check")
+            .arg("--bins")
+            .arg("--manifest-path")
+            .arg(manifest_path.join("Cargo.toml"))
+            .env("RUSTFLAGS", "-Z save-analysis")
+            .env("CARGO_TARGET_DIR", manifest_path.join("target/rls"));
+
+        let output = command.output()?;
+
+        if !output.status.success() {
+            return Err(
+                ErrorKind::Cargo(
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr).into_owned(),
+                ).into(),
+            );
+        }
     }
 
     Ok(())
@@ -78,39 +91,91 @@ pub fn crate_name_from_manifest_path(manifest_path: &Path) -> Result<String> {
 ///
 /// - `metadata`: The JSON metadata of the crate.
 fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> {
-    let targets = match metadata["packages"][0]["targets"].as_array() {
-        Some(targets) => targets,
-        None => return Err(ErrorKind::Json("targets is not an array").into()),
+    println!("{:#?}", metadata);
+    let root = match metadata["packages"][0]["name"].as_str() {
+        Some(root) => root,
+        None => return Err(ErrorKind::Json("resolve.root is not a string").into()),
     };
 
-    for target in targets {
-        let crate_types = match target["crate_types"].as_array() {
-            Some(crate_types) => crate_types,
-            None => return Err(ErrorKind::Json("crate types is not an array").into()),
-        };
-
-        for crate_type in crate_types {
-            let ty = match crate_type.as_str() {
-                Some(t) => t,
-                None => {
-                    return Err(
-                        ErrorKind::Json("crate type contents are not a string").into(),
-                    )
-                }
+    match root.split_whitespace().nth(0) {
+        Some(root) => {
+            let kind = &metadata["packages"][0]["targets"][0]["crate_types"][0];
+            println!("{:#?}", kind);
+            let string = match kind.as_str() {
+                Some(lib) => lib,
+                None => return Err(ErrorKind::Json("kind is not a string").into()),
             };
 
-            if ty == "lib" {
-                match target["name"].as_str() {
-                    Some(name) => return Ok(name.replace('-', "_")),
-                    None => return Err(ErrorKind::Json("target name is not a string").into()),
-                }
+            if string == "lib" {
+                Ok(root.to_owned().replace('-', "_"))
+            } else {
+                Ok(root.to_owned())
             }
-        }
+        },
+        None => Err(ErrorKind::Json("No value for resolve.root was found").into()),
+    }
+}
+
+
+/// Grab the name of the binary or library from it's `Cargo.toml` file.
+///
+/// ## Arguments
+///
+/// - manifest_path: The path to the location of `Cargo.toml` of the crate being documented
+pub fn workspace_members_from_metadata(manifest_path: &Path) -> Result<Vec<String>> {
+    let mut command = Command::new("cargo");
+
+    command
+        .arg("metadata")
+        .arg("--manifest-path")
+        .arg(manifest_path.join("Cargo.toml"))
+        .arg("--no-deps")
+        .arg("--format-version")
+        .arg("1");
+
+    let output = command.output()?;
+
+    if !output.status.success() {
+        return Err(
+            ErrorKind::Cargo(
+                output.status,
+                String::from_utf8_lossy(&output.stderr).into_owned(),
+            ).into(),
+        );
     }
 
-    Err(
-        ErrorKind::Json("cargo metadata contained no targets").into(),
-    )
+    let mut metadata = serde_json::from_slice(&output.stdout)?;
+    workspace_paths_from_metadata(&mut metadata)
+}
+
+/// Parse the paths of the workspace members from crate metadata.
+///
+/// ## Arguments
+///
+/// - metadata: The JSON metadata of the crate.
+fn workspace_paths_from_metadata(metadata: &mut serde_json::Value) -> Result<Vec<String>> {
+    let workspace_members = match metadata["workspace_members"].as_array_mut() {
+        Some(members) => members,
+        None => return Err(ErrorKind::Json("workspace_members is not an array").into()),
+    };
+
+    // workspace_members values have the form of (where {} indicates values that change):
+    // { wokspace_dir } { version } (path+file//{ path to dir})"
+    // We want to extract the "path to dir" and return those values in an array as a manifest
+    // path.
+    let mut paths = Vec::new();
+
+    for i in workspace_members.into_iter() {
+        // We know this always matches
+        let mut path = i.as_str().unwrap().to_owned().split("(path+file://").nth(1).unwrap().to_owned();
+        // We don't care about the final ) value so take it out"
+        let _ = path.pop();
+        // Cargo.toml will be appended later so we need the '/' here
+        path.push('/');
+        paths.push(path);
+    }
+
+    Ok(paths)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
rustdoc was unable to work with workspaced crates before. This commit
now allows that by searching for all workspaced crates and generating
docs for them one at a time.

This is a complete work in progress but I'd like to solicit feedback as I work on it. Namely I've run into a few problems so far:

- Fails on non lib dirs
- Fails for other reasons that I'm still debugging. (Try this against the rayon crate to see what I mean)

Either way I do want to parallelize this as well after the kinks are worked out. Was wondering if the output should be closer to what cargo doc currently outputs or do we want to keep what we have?