### PR TITLE
Add phantomjs to package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,8 @@
     "ember-source": "~2.14.0-beta.1",
     "ember-welcome-page": "^3.0.0",
     "eslint": "^4.2.0",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "phantomjs": "^2.1.7"
   },
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
phantomjs is already supposed to be built into travis but it doesn't
seem like it is for OSX. This adds it as a dev dependency to unbork the
build.

Fixes #109 