### PR TITLE
Infer target to document

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -7,6 +7,33 @@ use serde_json;
 
 use error::*;
 
+/// Generate and parse the metadata of a cargo project.
+///
+/// ## Arguments
+///
+/// - `manifest_path`: The path containing the `Cargo.toml` of the crate
+pub fn retrieve_metadata(manifest_path: &Path) -> Result<serde_json::Value> {
+    let output = Command::new("cargo")
+        .arg("metadata")
+        .arg("--manifest-path")
+        .arg(manifest_path.join("Cargo.toml"))
+        .arg("--no-deps")
+        .arg("--format-version")
+        .arg("1")
+        .output()?;
+
+    if !output.status.success() {
+        return Err(
+            ErrorKind::Cargo(
+                output.status,
+                String::from_utf8_lossy(&output.stderr).into_owned(),
+            ).into(),
+        );
+    }
+
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
 /// Invoke cargo to generate the save-analysis data for the crate being documented.
 ///
 /// ## Arguments
@@ -41,43 +68,12 @@ pub fn generate_analysis(manifest_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Grab the name of the binary or library from it's `Cargo.toml` file.
-///
-/// ## Arguments
-///
-/// - `manifest_path`: The path to the location of `Cargo.toml` of the crate being documented
-pub fn crate_name_from_manifest_path(manifest_path: &Path) -> Result<String> {
-    let mut command = Command::new("cargo");
-
-    command
-        .arg("metadata")
-        .arg("--manifest-path")
-        .arg(manifest_path.join("Cargo.toml"))
-        .arg("--no-deps")
-        .arg("--format-version")
-        .arg("1");
-
-    let output = command.output()?;
-
-    if !output.status.success() {
-        return Err(
-            ErrorKind::Cargo(
-                output.status,
-                String::from_utf8_lossy(&output.stderr).into_owned(),
-            ).into(),
-        );
-    }
-
-    let metadata = serde_json::from_slice(&output.stdout)?;
-    crate_name_from_metadata(&metadata)
-}
-
 /// Parse the crate name of the binary or library from crate metadata.
 ///
 /// ## Arguments
 ///
 /// - `metadata`: The JSON metadata of the crate.
-fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> {
+pub fn crate_name_from_metadata(metadata: &serde_json::Value) -> Result<String> {
     let targets = match metadata["packages"][0]["targets"].as_array() {
         Some(targets) => targets,
         None => return Err(ErrorKind::Json("targets is not an array").into()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ error_chain! {
 
         /// Thrown whenever the `JSON` grabbed from somewhere else is not what is expected.
         /// This is usually thrown when grabbing data output from `Cargo`
-        Json(location: &'static str) {
+        Json(location: String) {
             description("Unexpected JSON response")
             display("Unexpected JSON response from {}", location)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,9 @@ impl Config {
 /// - `config`: The `Config` struct that contains the data needed to generate the documentation
 /// - `artifacts`: A slice containing what assets should be output at the end
 pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
+    let metadata = cargo::retrieve_metadata(&config.manifest_path)?;
+    let crate_name = cargo::crate_name_from_metadata(&metadata)?;
     generate_and_load_analysis(config)?;
-
-    let crate_name = cargo::crate_name_from_manifest_path(&config.manifest_path)?;
 
     let output_path = config.manifest_path.join("target/doc");
     fs::create_dir_all(&output_path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use indicatif::ProgressBar;
 use rayon::prelude::*;
 
 use assets::Asset;
+use cargo::Target;
 use error::*;
 use json::*;
 
@@ -76,7 +77,7 @@ impl Config {
 pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
     let metadata = cargo::retrieve_metadata(&config.manifest_path)?;
     let target = cargo::target_from_metadata(&metadata)?;
-    generate_and_load_analysis(config)?;
+    generate_and_load_analysis(config, &target)?;
 
     let output_path = config.manifest_path.join("target/doc");
     fs::create_dir_all(&output_path)?;
@@ -86,7 +87,7 @@ pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
         spinner.enable_steady_tick(50);
         spinner.set_message("Generating JSON: In Progress");
 
-        let json = create_json(&config.host, &target.crate_name)?;
+        let json = create_json(&config.host, &target.crate_name())?;
 
         let mut json_path = output_path.clone();
         json_path.push("data.json");
@@ -123,14 +124,15 @@ pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
 ///
 /// - `config`: Contains data for what needs to be output or used. In this case the path to the
 ///             `Cargo.toml` file
-fn generate_and_load_analysis(config: &Config) -> Result<()> {
+/// - `target`: The target to document
+fn generate_and_load_analysis(config: &Config, target: &Target) -> Result<()> {
     let manifest_path = &config.manifest_path;
 
     let spinner = ProgressBar::new_spinner();
     spinner.enable_steady_tick(50);
     spinner.set_message("Generating save analysis data: In Progress");
 
-    if let Err(e) = cargo::generate_analysis(manifest_path) {
+    if let Err(e) = cargo::generate_analysis(manifest_path, target) {
         spinner.finish_with_message("Generating save analysis data: Error");
         return Err(e);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ impl Config {
 /// - `artifacts`: A slice containing what assets should be output at the end
 pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
     let metadata = cargo::retrieve_metadata(&config.manifest_path)?;
-    let crate_name = cargo::crate_name_from_metadata(&metadata)?;
+    let target = cargo::target_from_metadata(&metadata)?;
     generate_and_load_analysis(config)?;
 
     let output_path = config.manifest_path.join("target/doc");
@@ -86,7 +86,7 @@ pub fn build(config: &Config, artifacts: &[&str]) -> Result<()> {
         spinner.enable_steady_tick(50);
         spinner.set_message("Generating JSON: In Progress");
 
-        let json = create_json(&config.host, &crate_name)?;
+        let json = create_json(&config.host, &target.crate_name)?;
 
         let mut json_path = output_path.clone();
         json_path.push("data.json");


### PR DESCRIPTION
Fixes part of #105.

cc #104

This fixes a few issues with metadata and analysis generation.

- Fixes the way that we determine the type of target we are documenting. Previously we were looking at the `crate_type` key, but this key detemines the type of library, not the target type. We now correctly look at the `kind` key of the metadata.
- For crates that have a single target, we now always generate the analysis for that target. Notably this means that crates with a single binary will now work. Crates that have multiple targets will default to either the library (if one exists) or the first binary (this is arbitrary and should be fixed, which is why I'm leaving #105 open).

The diff of the first commit is pretty messy because I essentially inline one function into another and git can't figure it out, but the other commits should compare more cleanly.