### PR TITLE
Switch RLS back to a non git branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.6.3 (git+http://github.com/steveklabnik/rls-analysis)",
+ "rls-analysis 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -451,8 +451,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rls-analysis"
-version = "0.6.3"
-source = "git+http://github.com/steveklabnik/rls-analysis#43970b4ab1ec913154cab635ac7dd512ff72fd82"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -851,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum rls-analysis 0.6.3 (git+http://github.com/steveklabnik/rls-analysis)" = "<none>"
+"checksum rls-analysis 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d2cb40c0371765897ae428b5706bb17135705ad4f6d1b8b6afbaabcf8c9b5cff"
 "checksum rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d339f1888e33e74d8032de0f83c40b2bdaaaf04a8cfc03b32186c3481fb534"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,10 @@ clap = "2.24.2"
 error-chain = "=0.11.0-rc.2"
 indicatif = "0.6.0"
 rayon = "0.8.2"
+rls-analysis = "0.6.5"
 serde = "1.0.11"
 serde_derive = "1.0.11"
 serde_json = "1.0.2"
-
-[dependencies.rls-analysis]
-git = "http://github.com/steveklabnik/rls-analysis"
 
 [build-dependencies]
 error-chain = "=0.11.0-rc.2"


### PR DESCRIPTION
There was a public interface we needed that was made private by
accident. We were using a fork with the fix until it got pushed
upstream. It now is and the Cargo.toml file reflects this.

Fixes #116