### PR TITLE
Change --manifest-path to point to Cargo.toml.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
             "args": [
                 "run",
                 "--",
-                "--manifest-path=example",
+                "--manifest-path=example/Cargo.toml",
                 "build"
             ]
         },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,8 +127,8 @@ try to build docs for. For example, if you were going to build the docs for
 the `example` crate, located in this repo, you'd type this:
 
 ```bash
-> cargo run -- --manifest-path=example build
+> cargo run -- --manifest-path=example/Cargo.toml build
 ```
 
 "build" is the subcommand to build the docs, and `--manifest-path` should point
-to a directory where a `Cargo.toml` lives.
+to a `Cargo.toml`.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ those generated files.
 Currently, it only builds the given example. Do it as follow:
 
 ```
-cargo run --release -- --manifest-path=example
+cargo run --release -- --manifest-path=example/Cargo.toml
 ```
 
 Then open a web browser and open "rustdoc/example/target/doc/index.html".

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -48,12 +48,12 @@ impl Target {
 ///
 /// ## Arguments
 ///
-/// - `manifest_path`: The path containing the `Cargo.toml` of the crate
+/// - `manifest_path`: The path to the crate's `Cargo.toml`
 pub fn retrieve_metadata(manifest_path: &Path) -> Result<serde_json::Value> {
     let output = Command::new("cargo")
         .arg("metadata")
         .arg("--manifest-path")
-        .arg(manifest_path.join("Cargo.toml"))
+        .arg(manifest_path)
         .arg("--no-deps")
         .arg("--format-version")
         .arg("1")
@@ -75,7 +75,7 @@ pub fn retrieve_metadata(manifest_path: &Path) -> Result<serde_json::Value> {
 ///
 /// ## Arguments
 ///
-/// - `manifest_path`: The path containing the `Cargo.toml` of the crate
+/// - `manifest_path`: The path to the crate's Cargo.toml
 /// - `target`: The target that we should generate the analysis data for
 pub fn generate_analysis(
     manifest_path: &Path,
@@ -84,12 +84,17 @@ pub fn generate_analysis(
 ) -> Result<()> {
     let mut command = Command::new("cargo");
 
+    let target_dir = manifest_path
+        .parent()
+        .ok_or("Expected manifest_path to point to Cargo.toml")?
+        .join("target/rls");
+
     command
         .arg("check")
         .arg("--manifest-path")
-        .arg(manifest_path.join("Cargo.toml"))
+        .arg(manifest_path)
         .env("RUSTFLAGS", "-Z save-analysis")
-        .env("CARGO_TARGET_DIR", manifest_path.join("target/rls"))
+        .env("CARGO_TARGET_DIR", target_dir)
         .stderr(Stdio::piped())
         .stdout(Stdio::null());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn run() -> rustdoc::error::Result<()> {
             Arg::with_name("manifest-path")
                 .long("manifest-path")
                 // remove the unwrap in Config::new if this default_value goes away
-                .default_value(".")
+                .default_value("./Cargo.toml")
                 .help("The path to the Cargo manifest of the project you are documenting."),
         )
         .subcommand(

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -10,9 +10,10 @@ mod validation_tests {
 
     #[test]
     fn json_fmt_test() {
-        let config = Config::new(PathBuf::from("example"), vec![]).unwrap_or_else(|err| {
-            panic!("Couldn't create the config: {}", err);
-        });
+        let config = Config::new(PathBuf::from("example/Cargo.toml"), vec![])
+            .unwrap_or_else(|err| {
+                panic!("Couldn't create the config: {}", err);
+            });
 
         build(&config, &["json"]).unwrap_or_else(|err| {
             panic!("Error: {}", err);


### PR DESCRIPTION
Make the `--manifest-path` option consistent with Cargo's by having it
point to the `Cargo.toml`, rather than the directory containing the
`Cargo.toml`.

If the `--manifest-path` option is not provided, the default is still to
look for a `Cargo.toml` in the current working directory. This is
different behavior to Cargo, which attempts to look for a `Cargo.toml`
by traversing up through the current working directory and its parents.
A future enhancement could fix this, but it would make sense to wait for
the outcome of #155.

Fixes #113.