### PR TITLE
Show CI badges at top of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rustdoc
 
+[![Build Status](https://travis-ci.org/steveklabnik/rustdoc.svg?branch=master)](https://travis-ci.org/steveklabnik/rustdoc) [![Windows build status](https://ci.appveyor.com/api/projects/status/github/steveklabnik/rustdoc?svg=true)](https://ci.appveyor.com/project/steveklabnik/rustdoc)
+
 A tool for documenting Rust.
 
 > *NOTE*: This is not the "real" `rustdoc`. This is a prototype of a possible


### PR DESCRIPTION
The first time I ran `cargo test` I got an error, which turned out to be an out-of-date RLS that was fixed by `rustup update`.

However, before debugging the error, it would have been nice to have a quick way of checking that the tests were passing on master on the CI. This PR adds the Travis/Appveyor badges to the README to make it easier in the future.