### PR TITLE
Upgrade error-chain to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [dependencies]
 clap = "2.24.2"
-error-chain = "=0.11.0-rc.2"
+error-chain = "0.11"
 indicatif = "0.6.0"
 rayon = "0.8.2"
 rls-analysis = "0.6.5"
@@ -23,13 +23,13 @@ serde_derive = "1.0.11"
 serde_json = "1.0.2"
 
 [build-dependencies]
-error-chain = "=0.11.0-rc.2"
+error-chain = "0.11"
 quote = "0.3"
 syn = "0.11"
 walkdir = "1.0.7"
 
 [dev-dependencies]
-error-chain = "=0.11.0-rc.2"
+error-chain = "0.11"
 jsonapi = "0.5.2"
 lazy_static = "0.2"
 regex = "0.2"


### PR DESCRIPTION
We had used a prerelease of this to get rid of some annoying warnings.
This moves the code over to the final 0.11 release.

Closes #100