### PR TITLE
Adding all the DefKinds #121

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 **/*.rs.bk
+.vscode/launch.json

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -19,9 +19,48 @@ impl ExampleStruct{
     }
 }
 
+/// An enum.
+pub enum SampleEnum {
+    /// An enum variant.
+    EnumVariant,
+}
+
+/// An example function.
+///
+/// This function does stuff!
 pub fn sample_function(x: i32) -> ExampleStruct {
     let _ = x;
     ExampleStruct
+}
+
+/// A type ExampleType.
+type ExampleType = String;
+
+/// An example macro.
+macro_rules! example_macro {
+    () => ( println!("Hello!"); )
+}
+
+/// An example union.
+union example_union {
+    f1: u32,
+    f2: f32,
+}
+
+/// A const.
+const EXAMPLE_CONST: i32 = 5;
+
+/// A static.
+static EXAMPLE_STATIC: i32 = 5;
+
+/// A struct that contains another struct and other fields.
+///
+/// Docs for the ContainerStruct.
+pub struct ContainerStruct {
+    /// These are integer field docs.
+    integer: i32,
+    /// These are docs for the inner struct.
+    inner_struct: ExampleStruct,
 }
 
 /// An example module

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -61,6 +61,19 @@ pub fn create_documentation(host: &AnalysisHost, crate_name: &str) -> Result<Doc
         let (ty, child_ty) = match def.kind {
             DefKind::Mod => (String::from("module"), String::from("modules")),
             DefKind::Struct => (String::from("struct"), String::from("structs")),
+            DefKind::Enum => (String::from("enum"), String::from("enums")),
+            DefKind::Trait => (String::from("trait"), String::from("traits")),
+            DefKind::Function => (String::from("function"), String::from("functions")),
+            DefKind::Type => (String::from("type"), String::from("types")),
+            DefKind::Static => (String::from("static"), String::from("statics")),
+            DefKind::Const => (String::from("const"), String::from("consts")),
+            DefKind::Field => (String::from("field"), String::from("fields")),
+            DefKind::Tuple => continue,
+            DefKind::Local => continue,
+            // The below DefKinds are not supported in rls-analysis
+            // DefKind::Union => (String::from("union"), String::from("unions")),
+            // DefKind::Macro => (String::from("macro"), String::from("macros")),
+            // DefKind::Method => (String::from("method"), String::from("methods")),
             _ => continue,
         };
 
@@ -86,9 +99,22 @@ pub fn create_documentation(host: &AnalysisHost, crate_name: &str) -> Result<Doc
 
         // Using the item's metadata we create a new `Document` type to be put in the eventual
         // serialized JSON.
-        let (ty, child_ty) = match def.kind {
-            DefKind::Mod => (String::from("module"), String::from("child_modules")),
-            DefKind::Struct => (String::from("struct"), String::from("child_structs")),
+        let ty = match def.kind {
+            DefKind::Mod => String::from("module"),
+            DefKind::Struct => String::from("struct"),
+            DefKind::Enum => String::from("enum"),
+            DefKind::Trait => String::from("trait"),
+            DefKind::Function => String::from("function"),
+            DefKind::Type => String::from("type"),
+            DefKind::Static => String::from("static"),
+            DefKind::Const => String::from("const"),
+            DefKind::Field => String::from("field"),
+            DefKind::Tuple => continue,
+            DefKind::Local => continue,
+            // The below DefKinds are not supported in rls-analysis
+            // DefKind::Union => (String::from("union"), String::from("unions")),
+            // DefKind::Macro => (String::from("macro"), String::from("macros")),
+            // DefKind::Method => (String::from("method"), String::from("methods")),
             _ => continue,
         };
 
@@ -100,6 +126,24 @@ pub fn create_documentation(host: &AnalysisHost, crate_name: &str) -> Result<Doc
 
         for id in child_ids {
             let def = host.get_def(id).unwrap();
+            let (ty, child_ty) = match def.kind {
+                DefKind::Mod => (String::from("module"), String::from("child_modules")),
+                DefKind::Struct => (String::from("struct"), String::from("child_structs")),
+                DefKind::Enum => (String::from("enum"), String::from("child_enums")),
+                DefKind::Trait => (String::from("trait"), String::from("child_traits")),
+                DefKind::Function => (String::from("function"), String::from("child_functions")),
+                DefKind::Type => (String::from("type"), String::from("child_types")),
+                DefKind::Static => (String::from("static"), String::from("child_statics")),
+                DefKind::Const => (String::from("const"), String::from("child_consts")),
+                DefKind::Field => (String::from("field"), String::from("child_fields")),
+                DefKind::Tuple => continue,
+                DefKind::Local => continue,
+                // The below DefKinds are not supported in rls-analysis
+                // DefKind::Union => (String::from("union"), String::from("unions")),
+                // DefKind::Macro => (String::from("macro"), String::from("macros")),
+                // DefKind::Method => (String::from("method"), String::from("methods")),
+                _ => continue,
+            };
 
             let data = Data::new().ty(ty.clone()).id(def.qualname.clone());
 

--- a/tests/source/consts.rs
+++ b/tests/source/consts.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+
+// @has /data/relationships/consts/data/0/type 'const'
+// @has /data/relationships/consts/data/0/id 'consts::EXAMPLE_CONST'
+
+// @has /included/0/type 'const'
+// @has /included/0/id 'consts::EXAMPLE_CONST'
+// @has /included/0/attributes/docs 'A const.'
+// @has /included/0/attributes/name 'EXAMPLE_CONST'
+
+/// A const.
+pub const EXAMPLE_CONST: i32 = 5;

--- a/tests/source/enums.rs
+++ b/tests/source/enums.rs
@@ -1,0 +1,19 @@
+#![crate_type = "lib"]
+
+// @has /data/relationships/enums/data/0/type 'enum'
+// @has /data/relationships/enums/data/0/id 'enums::SampleEnum'
+
+// @has /included/0/type 'enum'
+// @has /included/0/id 'enums::SampleEnum'
+// @has /included/0/attributes/name 'SampleEnum'
+// @has /included/0/attributes/docs 'An enum.'
+
+// variants do not work yet, see https://github.com/nrc/rls-analysis/issues/98
+// has /included/0/relationships/child_enums/data/0/type 'enum'
+// has /included/0/relationships/child_enums/data/0/id 'enums::SampleEnum::EnumVariant'
+
+/// An enum.
+pub enum SampleEnum {
+    /// An enum variant.
+    EnumVariant,
+}

--- a/tests/source/fields.rs
+++ b/tests/source/fields.rs
@@ -1,0 +1,23 @@
+#![crate_type = "lib"]
+
+// @has /data/relationships/structs/data/0/type 'struct'
+// @has /data/relationships/structs/data/0/id 'fields::StructWithFields'
+
+// @has /included/0/type 'struct'
+// @has /included/0/id 'fields::StructWithFields'
+// @has /included/0/attributes/name 'StructWithFields'
+// @has /included/0/attributes/docs ''
+
+// @has /included/0/relationships/child_fields/data/0/type 'field'
+
+// @has /included/0/relationships/child_fields/data/0/id 'fields::StructWithFields::integer'
+
+// @has /included/1/type 'field'
+// @has /included/1/id 'fields::StructWithFields::integer'
+// @has /included/1/attributes/name 'integer'
+// @has /included/1/attributes/docs 'These are integer field docs.'
+
+pub struct StructWithFields {
+    /// These are integer field docs.
+    pub integer: i32,
+}

--- a/tests/source/functions.rs
+++ b/tests/source/functions.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+
+// @has /data/relationships/functions/data/0/type 'function'
+// @has /data/relationships/functions/data/0/id 'functions::empty_function'
+
+// @has /included/0/type 'function'
+// @has /included/0/id 'functions::empty_function'
+// @has /included/0/attributes/name 'empty_function'
+// @has /included/0/attributes/docs 'An empty function.'
+
+/// An empty function.
+pub fn empty_function() {}

--- a/tests/source/modules.rs
+++ b/tests/source/modules.rs
@@ -6,7 +6,7 @@
 // @has /included/0/type 'module'
 // @has /included/0/id 'modules::module'
 // @has /included/0/attributes/name 'module'
-// @has /included/0/attributes/docs 'a module'
+// @has /included/0/attributes/docs 'A module.'
 
-/// a module
+/// A module.
 pub mod module {}

--- a/tests/source/nested_modules.rs
+++ b/tests/source/nested_modules.rs
@@ -1,4 +1,4 @@
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
 // @has /included/0/relationships/child_modules/data/0/type 'module'
 // @has /included/0/relationships/child_modules/data/0/id 'nested_modules::example_module::nested'

--- a/tests/source/statics.rs
+++ b/tests/source/statics.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+
+// @has /data/relationships/statics/data/0/type 'static'
+// @has /data/relationships/statics/data/0/id 'statics::EXAMPLE_STATIC'
+
+// @has /included/0/type 'static'
+// @has /included/0/id 'statics::EXAMPLE_STATIC'
+// @has /included/0/attributes/docs 'A static.'
+// @has /included/0/attributes/name 'EXAMPLE_STATIC'
+
+/// A static.
+pub static EXAMPLE_STATIC: i32 = 5;

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -1,10 +1,30 @@
 #![crate_type = "lib"]
 
-/// A unit struct.
-pub struct UnitStruct;
+// @has /data/relationships/structs/data/0/type 'struct'
+// @has /data/relationships/structs/data/0/id 'structs::UnitStruct'
 
 // @has /included/0/type 'struct'
 // @has /included/0/id 'structs::UnitStruct'
 // @has /included/0/attributes/name 'UnitStruct'
 // @has /included/0/attributes/docs 'A unit struct.'
-// @has /data/relationships/structs/data/0/id 'structs::UnitStruct'
+
+/// A unit struct.
+pub struct UnitStruct;
+
+// @has /data/relationships/structs/data/1/type 'struct'
+// @has /data/relationships/structs/data/1/id 'structs::ContainerStruct'
+
+// @has /included/1/type 'struct'
+// @has /included/1/id 'structs::ContainerStruct'
+// @has /included/1/attributes/name 'ContainerStruct'
+// @has /included/1/attributes/docs 'A struct that contains another struct.'
+
+// @has /included/1/relationships/child_fields/data/0/type 'field'
+// @has /included/1/relationships/child_fields/data/0/id 'structs::ContainerStruct::inner_struct'
+
+/// A struct that contains another struct.
+/// Docs for the ContainerStruct.
+pub struct ContainerStruct {
+    /// These are docs for the inner struct.
+    pub inner_struct: UnitStruct,
+}

--- a/tests/source/traits.rs
+++ b/tests/source/traits.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+
+// @has /data/relationships/traits/data/0/type 'trait'
+// @has /data/relationships/traits/data/0/id 'traits::EmptyTrait'
+
+// @has /included/0/type 'trait'
+// @has /included/0/id 'traits::EmptyTrait'
+// @has /included/0/attributes/name 'EmptyTrait'
+// @has /included/0/attributes/docs 'An empty trait.'
+
+/// An empty trait.
+pub trait EmptyTrait {}

--- a/tests/source/types.rs
+++ b/tests/source/types.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+
+// @has /data/relationships/types/data/0/type 'type'
+// @has /data/relationships/types/data/0/id 'types::ExampleType'
+
+// @has /included/0/type 'type'
+// @has /included/0/id 'types::ExampleType'
+// @has /included/0/attributes/name 'ExampleType'
+// @has /included/0/attributes/docs 'A type ExampleType.'
+
+/// A type ExampleType.
+pub type ExampleType = String;


### PR DESCRIPTION
Addresses #121.

This excludes `Local`, which means it needs to be deliberately skipped. Maybe it should be more specific like `DefKind::Local => continue` in case something else is added in the future?

I'm not sure if it makes sense for `Static` or `Const` and such to have children?

I believe the idea is to set this boilerplate up and then we can move on to actually implementing things in the frontend?