### PR TITLE
WIP: Refactor cargo commands

### DIFF
--- a/src/cargo/command_bridge.rs
+++ b/src/cargo/command_bridge.rs
@@ -21,7 +21,7 @@ impl CommandBridge {
     pub fn new(command_name: &str) -> Self {
         CommandBridge {
             command_name: String::from(command_name),
-            .. Default::default()
+            ..Default::default()
         }
     }
 
@@ -40,7 +40,7 @@ impl CommandBridge {
         value_str.push(value.as_ref());
 
         self.env.insert(key_str, value_str);
-        
+
         self
     }
 
@@ -83,8 +83,7 @@ mod tests {
             // arrange
             let arg = OsString::from("some arg");
             // act
-            let cmd = CommandBridge::new("some cmd")
-                .arg(&arg);
+            let cmd = CommandBridge::new("some cmd").arg(&arg);
             // assert
             assert!(cmd.args.contains(&arg))
         }
@@ -99,8 +98,7 @@ mod tests {
             let key = OsString::from("hello");
             let value = OsString::from("world");
             // act
-            let cmd = CommandBridge::new("plop")
-                .env(&key, &value);
+            let cmd = CommandBridge::new("plop").env(&key, &value);
             // assert
             assert_eq!(&value, cmd.env.get(&key).unwrap())
         }
@@ -114,8 +112,7 @@ mod tests {
             // arrange
             let stdout = Stdio::null();
             // act
-            let _cmd = CommandBridge::new("plop")
-                .stdout(stdout);
+            let _cmd = CommandBridge::new("plop").stdout(stdout);
             // assert
             // FIXME: is there is really no way to compare an Stdio instance ??
             //assert_eq!(stdout as *const (), cmd.stdout.unwrap() as *const ())
@@ -130,12 +127,10 @@ mod tests {
             // arrange
             let stderr = Stdio::null();
             // act
-            let _cmd = CommandBridge::new("plop")
-                .stderr(stderr);
+            let _cmd = CommandBridge::new("plop").stderr(stderr);
             // assert
             // FIXME: is there is really no way to compare an Stdio instance ??
             //assert_eq!(stderr as *const (), cmd.stderr.unwrap() as *const ())
         }
     }
 }
-

--- a/src/cargo/command_bridge.rs
+++ b/src/cargo/command_bridge.rs
@@ -10,7 +10,7 @@ use std::process::{Command, Stdio};
 /// builder, as we can't inspect its structure and make assertions on it
 #[derive(Debug, Default)]
 pub struct CommandBridge {
-    pub name: String,
+    pub command_name: String,
     pub args: Vec<OsString>,
     pub env: HashMap<OsString, OsString>,
     pub stdout: Option<Stdio>,
@@ -18,21 +18,21 @@ pub struct CommandBridge {
 }
 
 impl CommandBridge {
-    pub fn new(name: &str) -> Self {
+    pub fn new(command_name: &str) -> Self {
         CommandBridge {
-            name: String::from(name),
+            command_name: String::from(command_name),
             .. Default::default()
         }
     }
 
-    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+    pub fn arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
         let mut os_string = OsString::new();
         os_string.push(arg);
-        self.args.push(os_string);
+        self.args.push(os_string.to_os_string());
         self
     }
 
-    pub fn env<S: AsRef<OsStr>>(&mut self, key: S, value: S) -> &mut Self {
+    pub fn env<S: AsRef<OsStr>>(mut self, key: S, value: S) -> Self {
         let mut key_str = OsString::new();
         let mut value_str = OsString::new();
 
@@ -44,18 +44,18 @@ impl CommandBridge {
         self
     }
 
-    pub fn stderr<S: Into<Stdio>>(&mut self, stderr: S) -> &mut Self {
+    pub fn stderr<S: Into<Stdio>>(mut self, stderr: S) -> Self {
         self.stderr = Some(stderr.into());
         self
     }
 
-    pub fn stdout<S: Into<Stdio>>(&mut self, stdout: S) -> &mut Self {
+    pub fn stdout<S: Into<Stdio>>(mut self, stdout: S) -> Self {
         self.stdout = Some(stdout.into());
         self
     }
 
     pub fn to_command(self) -> Command {
-        let mut command = Command::new(self.name);
+        let mut command = Command::new(self.command_name);
         command.args(self.args);
         command.envs(self.env);
 
@@ -82,9 +82,9 @@ mod tests {
         fn it_exists() {
             // arrange
             let arg = OsString::from("some arg");
-            let mut cmd = CommandBridge::new("some cmd");
             // act
-            cmd.arg(&arg);
+            let cmd = CommandBridge::new("some cmd")
+                .arg(&arg);
             // assert
             assert!(cmd.args.contains(&arg))
         }
@@ -98,9 +98,9 @@ mod tests {
             // arrange
             let key = OsString::from("hello");
             let value = OsString::from("world");
-            let mut cmd = CommandBridge::new("plop");
             // act
-            cmd.env(&key, &value);
+            let cmd = CommandBridge::new("plop")
+                .env(&key, &value);
             // assert
             assert_eq!(&value, cmd.env.get(&key).unwrap())
         }
@@ -112,10 +112,10 @@ mod tests {
         #[test]
         fn it_exists() {
             // arrange
-            let mut cmd = CommandBridge::new("plop");
             let stdout = Stdio::null();
             // act
-            cmd.stdout(stdout);
+            let _cmd = CommandBridge::new("plop")
+                .stdout(stdout);
             // assert
             // FIXME: is there is really no way to compare an Stdio instance ??
             //assert_eq!(stdout as *const (), cmd.stdout.unwrap() as *const ())
@@ -128,10 +128,10 @@ mod tests {
         #[test]
         fn it_exists() {
             // arrange
-            let mut cmd = CommandBridge::new("plop");
             let stderr = Stdio::null();
             // act
-            cmd.stderr(stderr);
+            let _cmd = CommandBridge::new("plop")
+                .stderr(stderr);
             // assert
             // FIXME: is there is really no way to compare an Stdio instance ??
             //assert_eq!(stderr as *const (), cmd.stderr.unwrap() as *const ())

--- a/src/cargo/command_bridge.rs
+++ b/src/cargo/command_bridge.rs
@@ -1,0 +1,141 @@
+//! This struct is a simple bridge that we can inspect for test purpose
+
+use std::collections::HashMap;
+use std::convert::{AsRef, Into};
+use std::default::Default;
+use std::ffi::{OsStr, OsString};
+use std::process::{Command, Stdio};
+
+/// This temporary struct is used to inspect the generated command before calling the process::Command
+/// builder, as we can't inspect its structure and make assertions on it
+#[derive(Debug, Default)]
+pub struct CommandBridge {
+    pub name: String,
+    pub args: Vec<OsString>,
+    pub env: HashMap<OsString, OsString>,
+    pub stdout: Option<Stdio>,
+    pub stderr: Option<Stdio>,
+}
+
+impl CommandBridge {
+    pub fn new(name: &str) -> Self {
+        CommandBridge {
+            name: String::from(name),
+            .. Default::default()
+        }
+    }
+
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        let mut os_string = OsString::new();
+        os_string.push(arg);
+        self.args.push(os_string);
+        self
+    }
+
+    pub fn env<S: AsRef<OsStr>>(&mut self, key: S, value: S) -> &mut Self {
+        let mut key_str = OsString::new();
+        let mut value_str = OsString::new();
+
+        key_str.push(key);
+        value_str.push(value);
+
+        self.env.insert(key_str, value_str);
+        
+        self
+    }
+
+    pub fn stderr<S: Into<Stdio>>(&mut self, stderr: S) -> &mut Self {
+        self.stderr = Some(stderr.into());
+        self
+    }
+
+    pub fn stdout<S: Into<Stdio>>(&mut self, stdout: S) -> &mut Self {
+        self.stdout = Some(stdout.into());
+        self
+    }
+
+    pub fn to_command(self) -> Command {
+        let mut command = Command::new(self.name);
+        command.args(self.args);
+        command.envs(self.env);
+
+        if let Some(stdio) = self.stdout {
+            command.stdout(stdio);
+        }
+
+        if let Some(stdio) = self.stderr {
+            command.stderr(stdio);
+        }
+
+        command
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod arg {
+        use super::*;
+
+        #[test]
+        fn it_exists() {
+            // arrange
+            let arg = OsString::from("some arg");
+            let mut cmd = CommandBridge::new("some cmd");
+            // act
+            cmd.arg(&arg);
+            // assert
+            assert!(cmd.args.contains(&arg))
+        }
+    }
+
+    mod env {
+        use super::*;
+
+        #[test]
+        fn it_exists() {
+            // arrange
+            let key = OsString::from("hello");
+            let value = OsString::from("world");
+            let mut cmd = CommandBridge::new("plop");
+            // act
+            cmd.env(&key, &value);
+            // assert
+            assert_eq!(&value, cmd.env.get(&key).unwrap())
+        }
+    }
+
+    mod stdout {
+        use super::*;
+
+        #[test]
+        fn it_exists() {
+            // arrange
+            let mut cmd = CommandBridge::new("plop");
+            let stdout = Stdio::null();
+            // act
+            cmd.stdout(stdout);
+            // assert
+            // FIXME: is there is really no way to compare an Stdio instance ??
+            //assert_eq!(stdout as *const (), cmd.stdout.unwrap() as *const ())
+        }
+    }
+
+    mod stderr {
+        use super::*;
+
+        #[test]
+        fn it_exists() {
+            // arrange
+            let mut cmd = CommandBridge::new("plop");
+            let stderr = Stdio::null();
+            // act
+            cmd.stderr(stderr);
+            // assert
+            // FIXME: is there is really no way to compare an Stdio instance ??
+            //assert_eq!(stderr as *const (), cmd.stderr.unwrap() as *const ())
+        }
+    }
+}
+

--- a/src/cargo/command_bridge.rs
+++ b/src/cargo/command_bridge.rs
@@ -36,8 +36,8 @@ impl CommandBridge {
         let mut key_str = OsString::new();
         let mut value_str = OsString::new();
 
-        key_str.push(key);
-        value_str.push(value);
+        key_str.push(key.as_ref());
+        value_str.push(value.as_ref());
 
         self.env.insert(key_str, value_str);
         

--- a/src/cargo/commands.rs
+++ b/src/cargo/commands.rs
@@ -6,14 +6,13 @@ use std::process::Stdio;
 use error::*;
 
 pub fn retrieve_metadata(manifest_path: &Path) -> CommandBridge {
-    let mut command = CommandBridge::new("cargo");
-    command.arg("metadata")
+    CommandBridge::new("cargo")
+        .arg("metadata")
         .arg("--manifest-path")
         .arg(manifest_path)
         .arg("--no-deps")
         .arg("--format-version")
-        .arg("1");
-    command
+        .arg("1")
 }
 
 pub fn generate_analysis(manifest_path: &PathBuf, is_verbose: bool) -> Result<CommandBridge> {
@@ -21,14 +20,12 @@ pub fn generate_analysis(manifest_path: &PathBuf, is_verbose: bool) -> Result<Co
     check_manifest_path_points_to_cargo_toml(manifest_path)?;
 
     const RLS_TARGET : &str = "target/rls";
-    let target_dir = manifest_path
+    let _target_dir = manifest_path
         .parent()
         .expect("Unreachable. If not, fill a bug about `check_manifest_path_points_to_cargo_toml`")
         .join(RLS_TARGET);
 
-    let mut command = CommandBridge::new("cargo");
-
-    command
+    let command = CommandBridge::new("cargo")
         .arg("check")
         .arg("--manifest-path")
         .arg(&manifest_path)
@@ -37,9 +34,11 @@ pub fn generate_analysis(manifest_path: &PathBuf, is_verbose: bool) -> Result<Co
         .stderr(Stdio::piped())
         .stdout(Stdio::null());
 
-    if is_verbose {
-        command.arg("--verbose");
-    }
+    let command = if is_verbose {
+        command.arg("--verbose")
+    } else {
+        command
+    };
 
     //match target.kind {
     //    TargetKind::Library => {

--- a/src/cargo/commands.rs
+++ b/src/cargo/commands.rs
@@ -1,0 +1,104 @@
+
+use cargo::command_bridge::CommandBridge;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use error::*;
+
+pub fn retrieve_metadata(manifest_path: &Path) -> CommandBridge {
+    let mut command = CommandBridge::new("cargo");
+    command.arg("metadata")
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .arg("--no-deps")
+        .arg("--format-version")
+        .arg("1");
+    command
+}
+
+pub fn generate_analysis(manifest_path: &PathBuf, is_verbose: bool) -> Result<CommandBridge> {
+
+    let mut command = CommandBridge::new("cargo");
+
+    //let target_dir = manifest_path
+    //    .parent()
+    //    .ok_or("Expected manifest_path to point to Cargo.toml")?
+    //    .join("target/rls");
+
+    command
+        .arg("check")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .env("RUSTFLAGS", "-Z save-analysis")
+        //.env("CARGO_TARGET_DIR", target_dir)
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null());
+
+    if is_verbose {
+        command.arg("--verbose");
+    }
+
+    //match target.kind {
+    //    TargetKind::Library => {
+    //        command.arg("--lib");
+    //    }
+    //    TargetKind::Binary => {
+    //      //  command.args(&["--bin", &target.name]);
+    //        ()
+    //    }
+    //}
+
+    Ok(command)
+}
+
+
+#[cfg(test)]
+mod tests {
+    pub use super::*;
+    pub use std::ffi::OsString;
+
+    mod retrieve_metadata {
+        pub use super::*;
+
+        #[test]
+        fn it_exists() {
+            // arrange
+            let path = Path::new(".");
+            // act
+            retrieve_metadata(path);
+            // assert
+        }
+
+        #[test]
+        fn it_should_add_the_manifest_path_in_arguments() {
+            // arrange
+            let path = Path::new("my-manifest-path");
+            // act
+            let cmd = retrieve_metadata(path);
+            // assert
+            assert!(cmd.args.contains(&OsString::from("my-manifest-path")))
+        }
+    }
+
+    mod generate_analysis {
+        use super::*;
+
+        #[test]
+        fn it_exists() {
+            // arrange
+            // act
+            let res = generate_analysis(&PathBuf::new(),false);
+            // assert
+            assert!(res.is_ok())
+        }
+
+        #[test]
+        fn it_should_add_verbose_flag_when_verbosity_is_enabled() {
+            // arrange
+            // act
+            let res = generate_analysis(&PathBuf::new(), true).unwrap();
+            // assert
+            assert!(res.args.contains(&OsString::from("--verbose")))
+        }
+    }
+}

--- a/src/cargo/commands.rs
+++ b/src/cargo/commands.rs
@@ -19,10 +19,12 @@ pub fn generate_analysis(manifest_path: &PathBuf, is_verbose: bool) -> Result<Co
 
     check_manifest_path_points_to_cargo_toml(manifest_path)?;
 
-    const RLS_TARGET : &str = "target/rls";
+    const RLS_TARGET: &str = "target/rls";
     let _target_dir = manifest_path
         .parent()
-        .expect("Unreachable. If not, fill a bug about `check_manifest_path_points_to_cargo_toml`")
+        .expect(
+            "Unreachable. If not, fill a bug about `check_manifest_path_points_to_cargo_toml`",
+        )
         .join(RLS_TARGET);
 
     let command = CommandBridge::new("cargo")
@@ -55,7 +57,7 @@ pub fn generate_analysis(manifest_path: &PathBuf, is_verbose: bool) -> Result<Co
 
 fn check_manifest_path_points_to_cargo_toml(manifest_path: &PathBuf) -> Result<()> {
 
-    const ERR_MSG : &str = "Expected manifest_path to point to Cargo.toml";
+    const ERR_MSG: &str = "Expected manifest_path to point to Cargo.toml";
 
     if let Some(file_name) = manifest_path.file_name() {
 
@@ -106,7 +108,7 @@ mod tests {
         fn it_exists() {
             // arrange
             // act
-            let res = generate_analysis(&PathBuf::from("Cargo.toml"),false);
+            let res = generate_analysis(&PathBuf::from("Cargo.toml"), false);
             // assert
             assert!(res.is_ok())
         }

--- a/src/cargo/mod.rs
+++ b/src/cargo/mod.rs
@@ -45,7 +45,7 @@ pub fn retrieve_metadata(manifest_path: &Path) -> Result<serde_json::Value> {
 /// - `config`: Rustdoc configuration
 /// - `target`: The target that we should generate the analysis data for
 /// - `report_progress`: A closure that should be called to report a progress message
-pub fn generate_analysis<F>(config: &Config, target: &Target, report_progress: F) -> Result<()>
+pub fn generate_analysis<F>(config: &Config, _target: &Target, report_progress: F) -> Result<()>
 where
     F: Fn(&str) -> (),
 {

--- a/src/cargo/mod.rs
+++ b/src/cargo/mod.rs
@@ -3,7 +3,6 @@
 use std::io::BufReader;
 use std::io::prelude::*;
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use serde_json;
 
@@ -12,39 +11,10 @@ use Verbosity;
 use error::*;
 use ui::Ui;
 
-/// The kinds of targets that we can document.
-#[derive(Debug, PartialEq, Eq)]
-pub enum TargetKind {
-    /// A `bin` target.
-    Binary,
-
-    /// A `lib` target.
-    Library,
-}
-
-/// A target of documentation.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Target {
-    /// The kind of the target.
-    pub kind: TargetKind,
-
-    /// The name of the target.
-    ///
-    /// This is *not* the name of the target's crate, which is used to retrieve the analysis data.
-    /// Use the [`crate_name`] method instead.
-    ///
-    /// [`crate_name`]: ./struct.Target.html#method.crate_name
-    pub name: String,
-}
-
-impl Target {
-    /// Returns the name of the target's crate.
-    ///
-    /// This name is equivalent to the target's name, with dashes replaced by underscores.
-    pub fn crate_name(&self) -> String {
-        self.name.replace('-', "_")
-    }
-}
+mod commands;
+mod command_bridge;
+mod target;
+pub use cargo::target::*;
 
 /// Generate and parse the metadata of a cargo project.
 ///
@@ -52,13 +22,8 @@ impl Target {
 ///
 /// - `manifest_path`: The path to the crate's `Cargo.toml`
 pub fn retrieve_metadata(manifest_path: &Path) -> Result<serde_json::Value> {
-    let output = Command::new("cargo")
-        .arg("metadata")
-        .arg("--manifest-path")
-        .arg(manifest_path)
-        .arg("--no-deps")
-        .arg("--format-version")
-        .arg("1")
+    let output = commands::retrieve_metadata(manifest_path)
+        .to_command()
         .output()?;
 
     if !output.status.success() {
@@ -84,35 +49,9 @@ pub fn generate_analysis<F>(config: &Config, target: &Target, report_progress: F
 where
     F: Fn(&str) -> (),
 {
-    let mut command = Command::new("cargo");
-
-    let target_dir = config
-        .manifest_path
-        .parent()
-        .ok_or("Expected manifest_path to point to Cargo.toml")?
-        .join("target/rls");
-
-    command
-        .arg("check")
-        .arg("--manifest-path")
-        .arg(&config.manifest_path)
-        .env("RUSTFLAGS", "-Z save-analysis")
-        .env("CARGO_TARGET_DIR", target_dir)
-        .stderr(Stdio::piped())
-        .stdout(Stdio::null());
-
-    if let Verbosity::Verbose = *config.ui.verbosity() {
-        command.arg("--verbose");
-    }
-
-    match target.kind {
-        TargetKind::Library => {
-            command.arg("--lib");
-        }
-        TargetKind::Binary => {
-            command.args(&["--bin", &target.name]);
-        }
-    }
+    let is_verbose = &Verbosity::Verbose == config.ui.verbosity();
+    let mut command = commands::generate_analysis(&config.manifest_path, is_verbose)?
+        .to_command();
 
     let mut child = command.spawn()?;
 

--- a/src/cargo/target.rs
+++ b/src/cargo/target.rs
@@ -1,0 +1,34 @@
+
+/// The kinds of targets that we can document.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TargetKind {
+    /// A `bin` target.
+    Binary,
+
+    /// A `lib` target.
+    Library,
+}
+
+/// A target of documentation.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Target {
+    /// The kind of the target.
+    pub kind: TargetKind,
+
+    /// The name of the target.
+    ///
+    /// This is *not* the name of the target's crate, which is used to retrieve the analysis data.
+    /// Use the [`crate_name`] method instead.
+    ///
+    /// [`crate_name`]: ./struct.Target.html#method.crate_name
+    pub name: String,
+}
+
+impl Target {
+    /// Returns the name of the target's crate.
+    ///
+    /// This name is equivalent to the target's name, with dashes replaced by underscores.
+    pub fn crate_name(&self) -> String {
+        self.name.replace('-', "_")
+    }
+}


### PR DESCRIPTION
I push this PR now for easier review + early discussions.

Todo:
- [x] extract the command building into their own testable module 
- [x] create a `Command` bridge that we can inspect before calling the true `Command` builder
- [ ] there is probably an opportunity to have a `utils` module, used by the cargo module
- [ ] remove dead code
- [ ] ?

EDIT: Oh I forgot to add my new nick I got from the RustFest:

Sincerly,
The Test Dude