### PR TITLE
[frontend] don't show crates and modules if there aren't any to show

### DIFF
--- a/frontend/app/templates/crates.hbs
+++ b/frontend/app/templates/crates.hbs
@@ -1,15 +1,17 @@
 <h1>Crate {{ model.id }}</h1>
 {{markdown-render model.docs }}
 
-<h2>Modules</h2>
-<ul>
-{{#each model.modules as |mod|}}
-  <li>
-    {{#link-to 'modules' mod }}
-      {{ mod.name }}
-    {{/link-to}}
-  </li>
-{{/each}}
-</ul>
+{{#if model.modules}}
+  <h2>Modules</h2>
+  <ul>
+  {{#each model.modules as |mod|}}
+    <li>
+      {{#link-to 'modules' mod }}
+        {{ mod.name }}
+      {{/link-to}}
+    </li>
+  {{/each}}
+  </ul>
+{{/if}}
 
 {{outlet}}

--- a/frontend/app/templates/modules.hbs
+++ b/frontend/app/templates/modules.hbs
@@ -1,17 +1,18 @@
 <h1>Module {{ model.name }}</h1>
 {{markdown-render model.docs }}
 
-<h2>Submodules</h2>
+{{#if model.child_modules}}
+  <h2>Submodules</h2>
 
-<ul>
-{{#each model.child_modules as |mod|}}
-  <li>
-    {{#link-to 'modules' mod }}
-      {{ mod.name }}
-    {{/link-to}}
-  </li>
-{{/each}}
-</ul>
-
+  <ul>
+  {{#each model.child_modules as |mod|}}
+    <li>
+      {{#link-to 'modules' mod }}
+        {{ mod.name }}
+      {{/link-to}}
+    </li>
+  {{/each}}
+  </ul>
+{{/if}}
 
 {{outlet}}


### PR DESCRIPTION
Currently crates and modules are shown even if there aren't any to show.