### PR TITLE
Generate full docs for public items only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -425,6 +426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rls-data"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rls-span"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rls-analysis 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4302cc8291570d7f817945845d8c01756e833dbc93c0a87d4f6c9a0b0b7992f1"
 "checksum rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d339f1888e33e74d8032de0f83c40b2bdaaaf04a8cfc03b32186c3481fb534"
+"checksum rls-data 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aea328fa69702c1b0fc395f2c71eae954bf984ac1e418c72f69221b6e3d15ff"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ error-chain = "0.11"
 indicatif = "0.6.0"
 open = "1.2.0"
 rls-analysis = "0.6.7"
+rls-data = { version = "0.11", features = ["serialize-serde"] }
 serde = "1.0.11"
 serde_derive = "1.0.11"
 serde_json = "1.0.2"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -5,6 +5,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+use analysis_data::config::Config as AnalysisConfig;
 use serde_json;
 
 use Config;
@@ -92,10 +93,20 @@ where
         .ok_or("Expected manifest_path to point to Cargo.toml")?
         .join("target/rls");
 
+    let analysis_config = AnalysisConfig {
+        full_docs: true,
+        pub_only: true,
+        ..Default::default()
+    };
+
     command
         .arg("check")
         .arg("--manifest-path")
         .arg(&config.manifest_path)
+        .env(
+            "RUST_SAVE_ANALYSIS_CONFIG",
+            serde_json::to_string(&analysis_config)?,
+        )
         .env("RUSTFLAGS", "-Z save-analysis")
         .env("CARGO_TARGET_DIR", target_dir)
         .stderr(Stdio::piped())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate serde_json;
 extern crate indicatif;
 extern crate open;
 extern crate rls_analysis as analysis;
+extern crate rls_data as analysis_data;
 
 pub mod assets;
 pub mod cargo;

--- a/tests/source/crates.rs
+++ b/tests/source/crates.rs
@@ -1,8 +1,11 @@
 #![crate_type = "lib"]
 
-//! Crate docs
+//! Crate docs.
+//!
+//! Multiline docs
 
 // @has /data/type 'crate'
 // @has /data/id 'crates'
 
 // @has /data/attributes/docs 'Crate docs'
+// @has /data/attributes/docs 'Multiline docs'

--- a/tests/source/nested_modules.rs
+++ b/tests/source/nested_modules.rs
@@ -2,11 +2,11 @@
 
 // @has /included/0/relationships/child_modules/data/0/type 'module'
 // @has /included/0/relationships/child_modules/data/0/id 'nested_modules::example_module::nested'
-mod example_module {
+pub mod example_module {
 
     // @has /included/1/relationships/child_modules/data/0/type 'module'
     // @has /included/1/relationships/child_modules/data/0/id 'nested_modules::example_module::nested::nested2'
-    mod nested {
-        mod nested2 {}
+    pub mod nested {
+        pub mod nested2 {}
     }
 }

--- a/tests/source/privacy.rs
+++ b/tests/source/privacy.rs
@@ -1,0 +1,14 @@
+#![crate_type = "lib"]
+
+// @has /included/0/id 'privacy::public'
+// @has /included/0/attributes/docs 'Public module'
+// @!has /included/1/id 'privacy::public::private'
+/// Public module.
+pub mod public {
+    mod private {}
+}
+
+// @!has /included/1/id 'privacy::private'
+// @!has /included/1/attributes/docs 'Private module'
+/// Private module.
+mod private {}


### PR DESCRIPTION
cc #79.
Resolves nrc/rls-analysis#99.

Notably this does *not* fix the fact that nested public items that aren't visible are still documented.