### PR TITLE
test all crates in workspace on CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,5 +9,6 @@ install:
 build: false
 
 test_script:
-  - cargo build
-  - cargo test
+  - cargo build --all
+  - cargo test --all
+  - cargo run -- --manifest-path=example\Cargo.toml build

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
   - rustfmt --write-mode diff $(find src -type f | grep .rs)
   - rustfmt $(find tests -type f | grep .rs) || true
   - cd frontend && npm install && npm run prod && npm run test
-  - cd .. && cargo build && cargo test && cd example
-  - ../target/debug/rustdoc build
+  - cd .. && cargo build --all && cargo test --all
+  - cargo run -- --manifest-path=example/Cargo.toml build


### PR DESCRIPTION
Now that `rustdoc-ember` is in a different crate, we should test it! We now attempt to build the documentation on AppVeyor as well.

Additionally, I was able to reproduce the issue that was occurring on travis. I'll open another issue for it, but this should work around the problem.