### PR TITLE
don't run rustfmt for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 script:
   - rustfmt --write-mode diff build.rs
   - rustfmt --write-mode diff $(find src -type f | grep .rs)
-  - rustfmt $(find tests -type f | grep .rs) || true
+    #- rustfmt $(find tests -type f | grep .rs) || true
   - cd frontend && npm install && npm run prod && npm run test
   - cd .. && cargo build --all && cargo test --all
   - cargo run -- --manifest-path=example/Cargo.toml build


### PR DESCRIPTION
related to https://github.com/steveklabnik/rustdoc/issues/98, our current
tests mean that some stuff has really long lines

Thoughts on this, everyone? I'm not sure there's a good way to tell rustfmt to ignore only these line lengths...