### PR TITLE
fall back to crate index if root not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ conforms to a particular interface.
 - The frontend must allow an `--output <path>` argument, for specifying where
   the frontend should output its files.
 - The frontend is free to generate whatever files it pleases in the output
-  directory, but typical frontends will at least generate `index.html` at the
-  root.
+  directory, but `rustdoc` expects that frontends generate an `index.html` file
+  at the root or the crate root (`crate_name/index.html`).
 
 To use an alternative frontend, set the `RUSTDOC_FRONTEND` environment variable
 to a path to a frontend binary.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,18 @@ impl Config {
 
     /// Open the generated docs in a web browser.
     pub fn open_docs(&self) -> Result<()> {
-        open::that(self.output_path().join("index.html"))?;
+        let mut index = self.output_path().join("index.html");
+
+        // If we can't find the index at the root, try looking in the crate folder.
+        if !index.is_file() {
+            let metadata = cargo::retrieve_metadata(&self.manifest_path)?;
+            let target = cargo::target_from_metadata(&self.ui, &metadata)?;
+            index = self.output_path().join(target.crate_name()).join(
+                "index.html",
+            );
+        }
+
+        open::that(index)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This allows frontends to generate documentation at the main crate's root, like the current rustdoc.