### PR TITLE
add summaries to doc output

### DIFF
--- a/src/json/attributes.rs
+++ b/src/json/attributes.rs
@@ -1,0 +1,58 @@
+//! Additional metadata processing for the documentation.
+
+use pulldown_cmark::{Event, Parser, Tag};
+
+/// Given a raw block of markdown, this function extracts the first paragraph and strips it of any
+/// formatting.
+pub fn plain_summary(markdown: &str) -> String {
+    let parser = Parser::new(markdown);
+
+    let mut summary = String::new();
+
+    for event in parser {
+        match event {
+            Event::Text(text) => summary.push_str(&text),
+            Event::Start(Tag::Code) |
+            Event::End(Tag::Code) => summary.push('`'),
+            Event::End(Tag::Paragraph) |
+            Event::End(Tag::Header(_)) => break,
+            _ => (),
+        }
+    }
+
+    summary
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn plain_summary() {
+        assert_eq!(&super::plain_summary("Summary\n\nDetails"), "Summary");
+
+        assert_eq!(&super::plain_summary("# Heading\n\nDetails"), "Heading");
+
+        assert_eq!(
+            &super::plain_summary("hello [Rust](https://www.rust-lang.org) :)"),
+            "hello Rust :)"
+        );
+
+        assert_eq!(
+            &super::plain_summary(r#"hello [Rust](https://www.rust-lang.org "Rust") :)"#),
+            "hello Rust :)"
+        );
+
+        assert_eq!(
+            &super::plain_summary("code `let x = i32;` ..."),
+            "code `let x = i32;` ..."
+        );
+
+        assert_eq!(
+            &super::plain_summary("type `Type<'static>` ..."),
+            "type `Type<'static>` ..."
+        );
+
+        assert_eq!(&super::plain_summary("# top header"), "top header");
+
+        assert_eq!(&super::plain_summary("## header"), "header");
+    }
+}

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,6 +1,7 @@
 //! Code used to serialize crate data to JSON.
 
 mod api;
+mod attributes;
 
 pub use self::api::*;
 
@@ -41,6 +42,10 @@ pub fn create_documentation(host: &AnalysisHost, crate_name: &str) -> Result<Doc
     let mut document = Document::new()
         .ty(String::from("crate"))
         .id(crate_name.to_string())
+        .attributes(
+            String::from("summary"),
+            attributes::plain_summary(&root_def.docs),
+        )
         .attributes(String::from("docs"), root_def.docs);
 
     // Now that we have that, it's time to get the children; these are
@@ -127,6 +132,10 @@ pub fn create_documentation(host: &AnalysisHost, crate_name: &str) -> Result<Doc
             .ty(ty.clone())
             .id(def.qualname.clone())
             .attributes(String::from("name"), def.name)
+            .attributes(
+                String::from("summary"),
+                attributes::plain_summary(&def.docs),
+            )
             .attributes(String::from("docs"), def.docs);
 
         for id in child_ids {

--- a/tests/source/crates.rs
+++ b/tests/source/crates.rs
@@ -8,4 +8,6 @@
 // @has data.id 'crates'
 
 // @has data.attributes.docs 'Crate docs'
+// @has data.attributes.summary 'Crate docs'
 // @has data.attributes.docs 'Multiline docs'
+// @!has data.attributes.summary 'Multiline docs'

--- a/tests/source/modules.rs
+++ b/tests/source/modules.rs
@@ -7,6 +7,7 @@
 // @has included[0].id 'modules::module'
 // @has included[0].attributes.name 'module'
 // @has included[0].attributes.docs 'A module.'
+// @has included[0].attributes.summary 'A module.'
 
 /// A module.
 pub mod module {}


### PR DESCRIPTION
This commit adds a new attribute "summary" to the doc output that contains the first paragraph of the doc block, with formatting removed. This logic is similar to that used by the existing rustdoc (in fact, it uses the same tests!).