### PR TITLE
Modules: parent links

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,85 +1,44 @@
-//! An example crate.
-//!
-//! This crate is used to test out the new rustdoc.
-//!
-//! It should have an example of almost everything, for testing
-//! purposes.
-
-/// An example struct.
-///
-/// This is mostly so that we can check the docs.
-pub struct ExampleStruct;
-
-impl ExampleStruct{
-    /// An example method.
-    ///
-    /// Sup.
-    pub fn example_method(&self) {
-        println!("Hello world");
-    }
-}
-
-/// An enum.
-pub enum SampleEnum {
-    /// An enum variant.
-    EnumVariant,
-}
-
-/// An example function.
-///
-/// This function does stuff!
-pub fn sample_function(x: i32) -> ExampleStruct {
-    let _ = x;
-    ExampleStruct
-}
-
-/// A type ExampleType.
-type ExampleType = String;
-
-/// An example macro.
-macro_rules! example_macro {
-    () => ( println!("Hello!"); )
-}
-
-/// An example union.
-union example_union {
-    f1: u32,
-    f2: f32,
-}
-
-/// A const.
-const EXAMPLE_CONST: i32 = 5;
-
-/// A static.
-static EXAMPLE_STATIC: i32 = 5;
-
-/// A struct that contains another struct and other fields.
-///
-/// Docs for the ContainerStruct.
-pub struct ContainerStruct {
-    /// These are integer field docs.
-    integer: i32,
-    /// These are docs for the inner struct.
-    inner_struct: ExampleStruct,
-}
-
-/// An example module
-///
-/// # Safety
-///
-/// Everything in this module is safe code, don't worry. If there was something unsafe,
-/// we'd use **GLORIOUS BOLD** *and italics* to highlight it.
+// Testing the child information:
+//
+// @has "included[?id=='nested_modules::example_module'] \
+//          .relationships.modules.data[].type | [0]" \
+//      "module"
+// @has "included[?id=='nested_modules::example_module'] \
+//          .relationships.modules.data[].id | [0]" \
+//      "nested_modules::example_module::nested"
+//
+// Testing that we don't have a parent:
+//
+// @matches "included[?id=='nested_modules::example_module'] \
+//          .relationships.parent" []
 pub mod example_module {
-    pub struct AnotherStruct;
-}
 
-/// nested 1
-pub mod nested1 {
-    /// nested 2
-    pub mod nested2 {
-        /// nested 3
-        pub mod nested3 {
-
-        }
+    // For the child:
+    //
+    // @has "included[?id=='nested_modules::example_module::nested'] \
+    //          .relationships.modules.data[].type | [0]" \
+    //      "module"
+    // @has "included[?id=='nested_modules::example_module::nested'] \
+    //          .relationships.modules.data[].id | [0]" \
+    //      "nested_modules::example_module::nested::nested2"
+    //
+    // For the parent:
+    //
+    // @has "included[?id=='nested_modules::example_module::nested'] \
+    //          .relationships.parent.data.type" \
+    //      "module"
+    // @has "included[?id=='nested_modules::example_module::nested'] \
+    //          .relationships.parent.data.id" \
+    //      "nested_modules::example_module"
+    pub mod nested {
+        // For the parent:
+        //
+        // @has "included[?id=='nested_modules::example_module::nested::nested2'] \
+        //          .relationships.parent.data.type" \
+        //      "module"
+        // @has "included[?id=='nested_modules::example_module::nested::nested2'] \
+        //          .relationships.parent.data.id" \
+        //      "nested_modules::example_module::nested"
+        pub mod nested2 {}
     }
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -129,6 +129,27 @@ pub fn create_documentation(host: &AnalysisHost, crate_name: &str) -> Result<Doc
             .attributes(String::from("name"), def.name)
             .attributes(String::from("docs"), def.docs);
 
+        // if this is a module...
+        if def.kind == DefKind::Mod {
+            // ... and it has a parent...
+            if let Some(parent_id) = def.parent {
+                // then we need to also add a relationship for the parent...
+                let parent_def = host.get_def(parent_id).unwrap();
+
+                // ... but only if the parent isn't the root, as that's
+                // represented by a crate, rather than by a module.
+                if parent_def.qualname != root_def.qualname {
+                    let data = Data::new().ty(String::from("module")).id(
+                        parent_def
+                            .qualname
+                            .clone(),
+                    );
+
+                    document.add_singular_relationship(String::from("parent"), data);
+                }
+            }
+        }
+
         for id in child_ids {
             let def = host.get_def(id).unwrap();
             let (ty, child_ty) = match def.kind {

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -414,7 +414,12 @@ fn parse_test(line: &str) -> Option<::std::result::Result<TestCase, InvalidDirec
     if let Some(caps) = DIRECTIVE_RE.captures(line) {
         let directive = &caps["directive"];
         let result = parse_directive(directive, &caps["args"], caps.name("negated").is_some())
-            .map_err(|e| InvalidDirective { d: line.into(), error: e });
+            .map_err(|e| {
+                InvalidDirective {
+                    d: line.into(),
+                    error: e,
+                }
+            });
         Some(result)
     } else {
         None

--- a/tests/source/nested_modules.rs
+++ b/tests/source/nested_modules.rs
@@ -1,20 +1,46 @@
 #![crate_type = "lib"]
 
+// Testing the child information:
+//
 // @has "included[?id=='nested_modules::example_module'] \
 //          .relationships.modules.data[].type | [0]" \
 //      "module"
 // @has "included[?id=='nested_modules::example_module'] \
 //          .relationships.modules.data[].id | [0]" \
 //      "nested_modules::example_module::nested"
+//
+// Testing that we don't have a parent:
+//
+// @matches "included[?id=='nested_modules::example_module'] \
+//          .relationships.parent" []
 pub mod example_module {
 
+    // For the child:
+    //
     // @has "included[?id=='nested_modules::example_module::nested'] \
     //          .relationships.modules.data[].type | [0]" \
     //      "module"
     // @has "included[?id=='nested_modules::example_module::nested'] \
     //          .relationships.modules.data[].id | [0]" \
     //      "nested_modules::example_module::nested::nested2"
+    //
+    // For the parent:
+    //
+    // @has "included[?id=='nested_modules::example_module::nested'] \
+    //          .relationships.parent.data.type | [0]" \
+    //      "module"
+    // @has "included[?id=='nested_modules::example_module::nested'] \
+    //          .relationships.parent.data.id | [0]" \
+    //      "nested_modules::example_module"
     pub mod nested {
+        // For the parent:
+        //
+        // @has "included[?id=='nested_modules::example_module::nested::nested2'] \
+        //          .relationships.parent.data.type | [0]" \
+        //      "module"
+        // @has "included[?id=='nested_modules::example_module::nested::nested2'] \
+        //          .relationships.parent.data.id | [0]" \
+        //      "nested_modules::example_module::nested"
         pub mod nested2 {}
     }
 }


### PR DESCRIPTION
We're gonna need to modify the JSON slightly to add parent links for modules. In theory, libraries could figure out that this is true, but in reality, they don't, and so this gives them a bit less work to do.

I have a failing test here, but am not likely to get it passing until tomorrow. If anyone wants to take a shot at this in the meantime, it would be very helpful!