### PR TITLE
log document creation

### DIFF
--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -186,6 +186,7 @@ pub fn create_documentation(host: &AnalysisHost, crate_name: &str) -> Result<Doc
             document.add_relationship(child_ty.clone(), data);
         }
 
+        debug!("adding document for {}", def.qualname);
         included.push(document);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ extern crate failure;
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
 extern crate indoc;
+#[macro_use]
+extern crate log;
 #[cfg_attr(test, macro_use)]
 extern crate quote;
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 //! Code used to drive the creation of documentation for Rust Crates.
 
 extern crate clap;
+extern crate env_logger;
+
 extern crate rustdoc;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
@@ -17,6 +19,8 @@ static ALL_ARTIFACTS: &[&str] = &["frontend", "json"];
 static DEFAULT_ARTIFACTS: &[&str] = &["frontend"];
 
 fn run() -> Result<()> {
+    env_logger::init().expect("could not initialize logger");
+
     let version = env!("CARGO_PKG_VERSION");
 
     let matches = App::new("rustdoc")


### PR DESCRIPTION
This is a tiny PR that logs when documents are being created. It also actually initializes env_logger, which we were depending on but not actually using! This PR is mostly useful for viewing rls-analysis' log output, but hopefully we'll add more of our own logging over time.