### PR TITLE
Fix failing CI due to rustfmt regression

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -248,6 +248,8 @@ mod tests {
     fn target_from_metadata() {
         let ui = Ui::default();
 
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let metadata = json!({
             "packages": [
             {
@@ -271,6 +273,8 @@ mod tests {
         );
         assert_eq!(&target.crate_name(), "underscored_name");
 
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let metadata = json!({
             "packages": [
             {
@@ -294,6 +298,8 @@ mod tests {
         );
         assert_eq!(&target.crate_name(), "dashed_name");
 
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let metadata = json!({
             "packages": [
             {
@@ -317,6 +323,8 @@ mod tests {
         );
         assert_eq!(&target.crate_name(), "underscored_name");
 
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let metadata = json!({
             "packages": [
             {
@@ -335,6 +343,8 @@ mod tests {
             TargetKind::Library
         );
 
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let metadata = json!({
             "packages": [
             {
@@ -353,6 +363,8 @@ mod tests {
             TargetKind::Binary
         );
 
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let metadata = json!({
             "packages": [
             {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -248,7 +248,19 @@ mod tests {
     fn target_from_metadata() {
         let ui = Ui::default();
 
-        let metadata = json!({});
+        let metadata = json!({
+            "packages": [
+            {
+                "name": "underscored_name",
+                "targets": [
+                {
+                    "kind": [ "lib" ],
+                    "name": "underscored_name",
+                },
+                ],
+            },
+            ],
+        });
         let target = super::target_from_metadata(&ui, &metadata).unwrap();
         assert_eq!(
             target,
@@ -259,7 +271,19 @@ mod tests {
         );
         assert_eq!(&target.crate_name(), "underscored_name");
 
-        let metadata = json!({});
+        let metadata = json!({
+            "packages": [
+            {
+                "name": "dashed-name",
+                "targets": [
+                {
+                    "kind": [ "lib" ],
+                    "name": "dashed-name",
+                },
+                ],
+            },
+            ],
+        });
         let target = super::target_from_metadata(&ui, &metadata).unwrap();
         assert_eq!(
             target,
@@ -270,7 +294,19 @@ mod tests {
         );
         assert_eq!(&target.crate_name(), "dashed_name");
 
-        let metadata = json!({});
+        let metadata = json!({
+            "packages": [
+            {
+                "name": "underscored_name",
+                "targets": [
+                {
+                    "kind": [ "bin" ],
+                    "name": "underscored_name",
+                },
+                ],
+            },
+            ],
+        });
         let target = super::target_from_metadata(&ui, &metadata).unwrap();
         assert_eq!(
             target,
@@ -281,19 +317,59 @@ mod tests {
         );
         assert_eq!(&target.crate_name(), "underscored_name");
 
-        let metadata = json!({});
+        let metadata = json!({
+            "packages": [
+            {
+                "name": "library",
+                "targets": [
+                {
+                    "kind": [ "lib" ],
+                    "name": "library",
+                },
+                ],
+            },
+            ],
+        });
         assert_eq!(
             super::target_from_metadata(&ui, &metadata).unwrap().kind,
             TargetKind::Library
         );
 
-        let metadata = json!({});
+        let metadata = json!({
+            "packages": [
+            {
+                "name": "binary",
+                "targets": [
+                {
+                    "kind": [ "bin" ],
+                    "name": "binary",
+                },
+                ],
+            },
+            ],
+        });
         assert_eq!(
             super::target_from_metadata(&ui, &metadata).unwrap().kind,
             TargetKind::Binary
         );
 
-        let metadata = json!({});
+        let metadata = json!({
+            "packages": [
+            {
+                "name": "library",
+                "targets": [
+                {
+                    "kind": [ "lib" ],
+                    "name": "library",
+                },
+                {
+                    "kind": [ "test" ],
+                    "name": "other_kind",
+                },
+                ],
+            },
+            ],
+        });
         assert_eq!(
             super::target_from_metadata(&ui, &metadata).unwrap().kind,
             TargetKind::Library

--- a/src/json/api.rs
+++ b/src/json/api.rs
@@ -332,6 +332,8 @@ mod tests {
     #[test]
     fn serialize() {
         let module_data = Data::new().ty("module".into()).id("example::module".into());
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let module_data_json = json!({
             "type": "module",
             "id": "example::module",
@@ -351,6 +353,8 @@ mod tests {
             .id("example::module".into())
             .attributes("docs".into(), "module docs".into())
             .attributes("name".into(), "module".into());
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let module_json = json!({
             "type": "module",
             "id": "example::module",

--- a/src/json/api.rs
+++ b/src/json/api.rs
@@ -332,10 +332,13 @@ mod tests {
     #[test]
     fn serialize() {
         let module_data = Data::new().ty("module".into()).id("example::module".into());
-        let module_data_json = json!({});
+        let module_data_json = json!({
+            "type": "module",
+            "id": "example::module",
+        });
         assert_eq!(
-            module_data_json,
-            serde_json::to_value(&module_data).unwrap()
+            serde_json::to_value(&module_data).unwrap(),
+            module_data_json
         );
 
         let mut krate = Document::new()
@@ -348,7 +351,14 @@ mod tests {
             .id("example::module".into())
             .attributes("docs".into(), "module docs".into())
             .attributes("name".into(), "module".into());
-        let module_json = json!({});
+        let module_json = json!({
+            "type": "module",
+            "id": "example::module",
+            "attributes": {
+                "docs": "module docs",
+                "name": "module",
+            },
+        });
         assert_eq!(serde_json::to_value(&module).unwrap(), module_json);
 
         krate.relationships("modules".into(), vec![module_data]);

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -571,6 +571,8 @@ mod tests {
 
     #[test]
     fn run_test() {
+        // work around until https://github.com/rust-lang-nursery/rustfmt/issues/2344 is fixed
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let json = json!({
             "test": "value",
             "nonString": ["non", "string"],

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -571,7 +571,11 @@ mod tests {
 
     #[test]
     fn run_test() {
-        let json = json!({});
+        let json = json!({
+            "test": "value",
+            "nonString": ["non", "string"],
+            "boolean": true,
+        });
 
         let test = TestCase {
             jmespath: jmespath::compile("test").unwrap(),


### PR DESCRIPTION
This fixes the failing tests and adds a temporary fix for a regression in rustfmt so the CI process
will correctly run. I broke this into two commits so (theoretically) we can just back out the temporary fix.

Fixes #223
  