### PR TITLE
Do not check subcommands for moved flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,11 +235,10 @@ fn check_moved_flags(matches: &ArgMatches) -> Result<()> {
         ("target", build_msg),
         ("sysroot", build_msg),
         ("test", "Use in conjunction with the test subcommand."),
-        ("test", "Use the test subcommand."),
     ];
 
     for &(flag, err_msg) in moved_flags.iter() {
-        if matches.is_present(flag) {
+        if matches.args.contains_key(flag) {
             return Err(error::MovedFlag {
                 flag_name: flag.to_string(),
                 msg: err_msg.to_string(),


### PR DESCRIPTION
In b864a9e, the check for moved flags was using `is_present` which
checks flags in subcommands. This caused a lot of false positives.
Instead, look at the args at the top level only and check if the flag
exists there.