### PR TITLE
Add missing `FromStr` import for test.

### DIFF
--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -6,6 +6,7 @@ mod validation_tests {
     use std::fs::File;
     use std::io::Read;
     use std::path::{Path, PathBuf};
+    use std::str::FromStr;
     use rustdoc::{build, Config, Verbosity};
 
     #[test]


### PR DESCRIPTION
When I run `cargo test`, I get an error saying this trait is needed for
the `JsonApiDocument::from_str` call.